### PR TITLE
Fix gethrtime for Solaris.

### DIFF
--- a/base/htime.c
+++ b/base/htime.c
@@ -41,8 +41,7 @@ unsigned int gettick() {
 #endif
 }
 
-#ifndef OS_SOLARIS
-unsigned long long gethrtime() {
+unsigned long long gethrtime_usec() {
 #ifdef OS_WIN
     static LONGLONG s_freq = 0;
     if (s_freq == 0) {
@@ -56,6 +55,8 @@ unsigned long long gethrtime() {
         return (unsigned long long)(count.QuadPart / (double)s_freq * 1000000);
     }
     return 0;
+#elif defined(OS_SOLARIS)
+    return gethrtime() / 1000;
 #elif HAVE_CLOCK_GETTIME
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -66,7 +67,6 @@ unsigned long long gethrtime() {
     return tv.tv_sec*(unsigned long long)1000000 + tv.tv_usec;
 #endif
 }
-#endif
 
 datetime_t datetime_now() {
     datetime_t  dt;

--- a/base/htime.h
+++ b/base/htime.h
@@ -72,11 +72,8 @@ static inline unsigned long long timestamp_ms() {
 void msleep(unsigned int ms);
 // ms
 unsigned int gettick();
-
-#ifndef OS_SOLARIS  // Solaris has built-in gethrtime().
 // us
-unsigned long long gethrtime();
-#endif
+unsigned long long gethrtime_usec();
 
 datetime_t datetime_now();
 time_t     datetime_mktime(datetime_t* dt);

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -34,7 +34,7 @@
 - datetime_fmt
 - gmtime_fmt
 - gettick
-- gethrtime
+- gethrtime_usec
 - sleep
 - msleep
 - usleep

--- a/event/hloop.c
+++ b/event/hloop.c
@@ -175,7 +175,7 @@ static void hloop_init(hloop_t* loop) {
     hmutex_init(&loop->custom_events_mutex);
     // NOTE: init start_time here, because htimer_add use it.
     loop->start_ms = timestamp_ms();
-    loop->start_hrtime = loop->cur_hrtime = gethrtime();
+    loop->start_hrtime = loop->cur_hrtime = gethrtime_usec();
 }
 
 static void hloop_cleanup(hloop_t* loop) {
@@ -268,7 +268,7 @@ int hloop_run(hloop_t* loop) {
         }
     }
     loop->status = HLOOP_STATUS_STOP;
-    loop->end_hrtime = gethrtime();
+    loop->end_hrtime = gethrtime_usec();
     if (loop->flags & HLOOP_FLAG_AUTO_FREE) {
         hloop_cleanup(loop);
         SAFE_FREE(loop);
@@ -296,7 +296,7 @@ int hloop_resume(hloop_t* loop) {
 }
 
 void hloop_update_time(hloop_t* loop) {
-    loop->cur_hrtime = gethrtime();
+    loop->cur_hrtime = gethrtime_usec();
     if (ABS((int64_t)hloop_now(loop) - (int64_t)time(NULL)) > 1) {
         // systemtime changed, we adjust start_ms
         loop->start_ms = timestamp_ms() - (loop->cur_hrtime - loop->start_hrtime) / 1000;

--- a/protocol/icmp.c
+++ b/protocol/icmp.c
@@ -67,7 +67,7 @@ int ping(const char* host, int cnt) {
         icmp_req->icmp_seq = ++seq;
         icmp_req->icmp_cksum = 0;
         icmp_req->icmp_cksum = checksum((uint8_t*)icmp_req, sendbytes);
-        start_hrtime = gethrtime();
+        start_hrtime = gethrtime_usec();
         addrlen = sockaddrlen(&peeraddr);
         int nsend = sendto(sockfd, sendbuf, sendbytes, 0, &peeraddr.sa, addrlen);
         if (nsend < 0) {
@@ -82,7 +82,7 @@ int ping(const char* host, int cnt) {
             continue;
         }
         ++recv_cnt;
-        end_hrtime = gethrtime();
+        end_hrtime = gethrtime_usec();
         // check valid
         bool valid = false;
         int iphdr_len = ipheader->ihl * 4;


### PR DESCRIPTION
I made a mistake in the previous pull request. 

The `gethtrime()` return value in libhv is in microseconds rather than nanoseconds. Renamed to `gethrtime_usec()` to avoid conflit with Solaris' built-in `gethrtime()`.