### PR TITLE
Add Unix domain socket support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 
 default: all
 all: libhv examples
-examples: test timer loop tcp udp nc nmap httpd curl consul_cli
+examples: test timer loop stream_server dgram_server nc nmap httpd curl consul_cli
 
 clean:
 	$(MAKEF) clean SRCDIRS="$(ALL_SRCDIRS)"
@@ -62,11 +62,11 @@ timer: prepare
 loop: prepare
 	$(MAKEF) TARGET=$@ SRCDIRS=". base event" SRCS="examples/hloop_test.c"
 
-tcp: prepare
-	$(MAKEF) TARGET=$@ SRCDIRS=". base event" SRCS="examples/tcp.c"
+stream_server: prepare
+	$(MAKEF) TARGET=$@ SRCDIRS=". base event" SRCS="examples/stream_server.c"
 
-udp: prepare
-	$(MAKEF) TARGET=$@ SRCDIRS=". base event" SRCS="examples/udp.c"
+dgram_server: prepare
+	$(MAKEF) TARGET=$@ SRCDIRS=". base event" SRCS="examples/dgram_server.c"
 
 nc: prepare
 	$(MAKEF) TARGET=$@ SRCDIRS=". base event" SRCS="examples/nc.c"

--- a/Makefile.in
+++ b/Makefile.in
@@ -124,6 +124,10 @@ else
 	CPPFLAGS += -DNDEBUG
 endif
 
+ifeq ($(ENABLE_UDS), yes)
+	CPPFLAGS += -DENABLE_UDS
+endif
+
 CPPFLAGS += $(addprefix -D, $(DEFINES))
 CPPFLAGS += $(addprefix -I, $(INCDIRS))
 CPPFLAGS += $(addprefix -I, $(SRCDIRS))

--- a/README.md
+++ b/README.md
@@ -154,12 +154,19 @@ int main(int argc, char** argv) {
 }
 ```
 ```shell
-make tcp udp nc
-bin/tcp 1111
+make stream_server dgram_server nc
+# TCP server/client
+bin/stream_server 1111
 bin/nc 127.0.0.1 1111
-
-bin/udp 2222
+# UDP server/client
+bin/dgram_server 2222
 bin/nc -u 127.0.0.1 2222
+# Unix stream socket server/client
+bin/stream_server --unix ~/server.sock
+bin/nc -U ~/client.sock ~/server.sock
+# Unix datagram socket server/client
+bin/dgram_server --unix ~/server.sock
+bin/nc -D ~/client.sock ~/server.sock
 ```
 
 ## BUILD
@@ -173,8 +180,8 @@ bin/nc -u 127.0.0.1 2222
     - make test # master-workers model
     - make timer # timer add/del/reset
     - make loop # event-loop(include idle, timer, io)
-    - make tcp  # tcp server
-    - make udp  # udp server
+    - make stream_server  # stream socket server (TCP, Unix domain socket)
+    - make dgram_server  # datagram socket server (UDP, Unix domain socket)
     - make nc   # network client
     - make nmap # host discovery
     - make httpd # http server

--- a/base/hplatform.h
+++ b/base/hplatform.h
@@ -127,6 +127,13 @@
     #include <direct.h>     // for mkdir,rmdir,chdir,getcwd
     #include <io.h>         // for open,close,read,write,lseek,tell
 
+    #ifdef ENABLE_UDS
+    // TODO: support Unix domain socket on Windows
+    // #define HAVE_UDS
+    // #include <afunix.h>
+    #warning "Unix domain socket is not yet supported on Windows"
+    #endif
+
     #define MKDIR(dir)      mkdir(dir)
     #ifndef S_ISREG
     #define S_ISREG(st_mode) (((st_mode) & S_IFMT) == S_IFREG)
@@ -146,6 +153,11 @@
     #include <netinet/tcp.h>
     #include <netinet/udp.h>
     #include <netdb.h>  // for gethostbyname
+
+    #ifdef ENABLE_UDS
+    #define HAVE_UDS
+    #include <sys/un.h>    // For Unix domain sockets
+    #endif
 
     #define MKDIR(dir)      mkdir(dir, 0777)
 #endif

--- a/config.mk
+++ b/config.mk
@@ -12,6 +12,8 @@ WITH_CONSUL=no
 # features
 # base/hsocket.c: replace gethostbyname with getaddrinfo
 ENABLE_IPV6=no
+# event/hloop.h: Enable Unix domains socket server/client APIs
+ENABLE_UDS=no
 # base/RAII.cpp: Windows MiniDumpWriteDump
 ENABLE_WINDUMP=no
 # http/http_content.h: QueryParams,MultiPart

--- a/event/hloop.h
+++ b/event/hloop.h
@@ -233,6 +233,14 @@ hio_t* create_udp_server (hloop_t* loop, const char* host, int port);
 // @udp_client: resolver -> socket -> hio_get -> hio_set_peeraddr
 hio_t* create_udp_client (hloop_t* loop, const char* host, int port);
 
+#ifdef HAVE_UDS
+// Unix domain socket server/client
+hio_t* create_unix_stream_server (hloop_t* loop, const char* path, haccept_cb accept_cb);
+hio_t* create_unix_stream_client (hloop_t* loop, const char* dest_path, const char* src_path, hconnect_cb connect_cb);
+hio_t* create_unix_dgram_server  (hloop_t* loop, const char* path);
+hio_t* create_unix_dgram_client  (hloop_t* loop, const char* dest_path, const char* src_path);
+#endif
+
 END_EXTERN_C
 
 #endif // HV_LOOP_H_

--- a/event/nio.c
+++ b/event/nio.c
@@ -324,7 +324,7 @@ static void connect_timeout_cb(htimer_t* timer) {
 }
 
 int hio_connect(hio_t* io) {
-    int ret = connect(io->fd, io->peeraddr, sizeof(sockaddr_u));
+    int ret = connect(io->fd, io->peeraddr, sockaddrlen((sockaddr_u*)io->peeraddr));
 #ifdef OS_WIN
     if (ret < 0 && socket_errno() != WSAEWOULDBLOCK) {
 #else

--- a/event/nio.c
+++ b/event/nio.c
@@ -370,7 +370,7 @@ try_write:
             break;
         case HIO_TYPE_UDP:
         case HIO_TYPE_IP:
-            nwrite = sendto(io->fd, buf, len, 0, io->peeraddr, sizeof(sockaddr_u));
+            nwrite = sendto(io->fd, buf, len, 0, io->peeraddr, sockaddrlen((sockaddr_u*)io->peeraddr));
             break;
         default:
             nwrite = write(io->fd, buf, len);

--- a/examples/dgram_server.c
+++ b/examples/dgram_server.c
@@ -1,6 +1,16 @@
 #include "hloop.h"
 #include "hsocket.h"
 
+const char* path = NULL;
+
+void cleanup(int signo) {
+    if (path) {
+        printf("cleaning up: %s\n", path);
+        unlink(path);
+    }
+    exit(0);
+}
+
 void on_close(hio_t* io) {
     printf("on_close fd=%d error=%d\n", hio_fd(io), hio_error(io));
 }
@@ -19,20 +29,37 @@ void on_recvfrom(hio_t* io, void* buf, int readbytes) {
 }
 
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        printf("Usage: cmd port\n");
-        return -10;
+    int port;
+    if (argc == 2) {
+        port = atoi(argv[1]);
     }
-    int port = atoi(argv[1]);
+    else if (argc == 3 && strcmp(argv[1], "--unix") == 0) {
+        path = argv[2];
+    }
+    else {
+        printf("Usage: cmd port\n"
+               "       cmd --unix path\n");
+        return -10;
+    };
 
     hloop_t* loop = hloop_new(0);
-    hio_t* io = create_udp_server(loop, "0.0.0.0", port);
-    if (io == NULL) {
-        return -20;
+    hio_t* io = NULL;
+    if (path) {
+#ifdef HAVE_UDS
+        io = create_unix_dgram_server(loop, path);
+#else
+        printf("Unix domain socket is not supported!\n");
+#endif
+    } else {
+        io = create_udp_server(loop, "0.0.0.0", port);
     }
     hio_setcb_close(io, on_close);
     hio_setcb_read(io, on_recvfrom);
     hio_read(io);
+
+    signal(SIGINT, cleanup);
+    signal(SIGTERM, cleanup);
+
     hloop_run(loop);
     hloop_free(&loop);
     return 0;

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -153,12 +153,19 @@ int main(int argc, char** argv) {
 }
 ```
 ```shell
-make tcp udp nc
-bin/tcp 1111
+make stream_server dgram_server nc
+# TCP server/client
+bin/stream_server 1111
 bin/nc 127.0.0.1 1111
-
-bin/udp 2222
+# UDP server/client
+bin/dgram_server 2222
 bin/nc -u 127.0.0.1 2222
+# Unix stream socket server/client
+bin/stream_server --unix ~/server.sock
+bin/nc -U ~/client.sock ~/server.sock
+# Unix datagram socket server/client
+bin/dgram_server --unix ~/server.sock
+bin/nc -D ~/client.sock ~/server.sock
 ```
 
 ## 构建
@@ -172,8 +179,8 @@ bin/nc -u 127.0.0.1 2222
     - make test # master-workers model
     - make timer # timer add/del/reset
     - make loop # event-loop(include idle, timer, io)
-    - make tcp  # tcp server
-    - make udp  # udp server
+    - make stream_server  # stream socket server (TCP, Unix domain socket)
+    - make dgram_server  # datagram socket server (UDP, Unix domain socket)
     - make nc   # network client
     - make nmap # host discovery
     - make httpd # http server


### PR DESCRIPTION
Updates: 
* Add support for Unix domain sockets in `hsocket`.
  * Rearranged some code so that many of them can be reused, reducing boilerplates.
* Add Unix stream/datagram socket server/client API in `hloop`.
* Add Unix domain socket support in server/client examples.
  * `tcp.c` and `udp.c` examples renamed to `stream_server.c` and `dgram_server.c`, and by specifying `--unix` argument, the server will bind to Unix domain socket instead of IP ports.
  * Add Unix domain socket client support in `nc.c` (`-U` and `-D` arguments).
* Update README documentation for the new features.

Notes:
* Although Windows began supporting Unix domain sockets as of late 2018, it is not supported yet in this pull request.
* This feature is not enabled by default, change `ENABLE_UDS=yes` in `config.mk` to enable it.