### PR TITLE
TcpClient修正断链无法重连的BUG

### DIFF
--- a/evpp/Channel.h
+++ b/evpp/Channel.h
@@ -115,7 +115,7 @@ public:
     } status;
     std::function<void(Buffer*)> onread;
     std::function<void(Buffer*)> onwrite;
-    std::function<void()>        onclose;
+    std::function<void(Status status)> onclose;
 
 private:
     static void on_read(hio_t* io, void* data, int readbytes) {
@@ -137,9 +137,10 @@ private:
     static void on_close(hio_t* io) {
         Channel* channel = (Channel*)hio_context(io);
         if (channel) {
+            Status status = channel->status;
             channel->status = CLOSED;
             if (channel->onclose) {
-                channel->onclose();
+                channel->onclose(status);
             }
         }
     }

--- a/evpp/TcpClient.h
+++ b/evpp/TcpClient.h
@@ -93,7 +93,7 @@ public:
         channel->onconnect = [this]() {
             channel->startRead();
             if (onConnection) {
-                onConnection(channel);
+                onConnection(channel, Channel::CONNECTING);
             }
         };
         channel->onread = [this](Buffer* buf) {
@@ -106,11 +106,11 @@ public:
                 onWriteComplete(channel, buf);
             }
         };
-        channel->onclose = [this]() {
+        channel->onclose = [this](Channel::Status last_status) {
             if (onConnection) {
-                onConnection(channel);
+                onConnection(channel, last_status);
             }
-            channel = NULL;
+            // channel = NULL;  // 对channel的清空操作，会导致enable_reconnect失效
             // reconnect
             if (enable_reconnect) {
                 startReconnect();
@@ -181,9 +181,9 @@ public:
     ReconnectInfo           reconnect_info;
 
     // Callback
-    std::function<void(const TSocketChannelPtr&)>           onConnection;
-    std::function<void(const TSocketChannelPtr&, Buffer*)>  onMessage;
-    std::function<void(const TSocketChannelPtr&, Buffer*)>  onWriteComplete;
+    std::function<void(const TSocketChannelPtr&, Channel::Status)> onConnection;
+    std::function<void(const TSocketChannelPtr&, Buffer*)>         onMessage;
+    std::function<void(const TSocketChannelPtr&, Buffer*)>         onWriteComplete;
 private:
     EventLoopThread         loop_thread;
 };

--- a/evpp/TcpClient_test.cpp
+++ b/evpp/TcpClient_test.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[]) {
         return -20;
     }
     printf("client connect to port %d, connfd=%d ...\n", port, connfd);
-    cli.onConnection = [](const SocketChannelPtr& channel) {
+    cli.onConnection = [](const SocketChannelPtr& channel, Channel::Status last_status) {
         std::string peeraddr = channel->peeraddr();
         if (channel->isConnected()) {
             printf("connected to %s! connfd=%d\n", peeraddr.c_str(), channel->fd());
@@ -40,8 +40,10 @@ int main(int argc, char* argv[]) {
                     killTimer(timerID);
                 }
             });
-        } else {
+        } else if ( Channel::CONNECTED == last_status) {
             printf("disconnected to %s! connfd=%d\n", peeraddr.c_str(), channel->fd());
+        } else {
+            printf("reconnect to %s failed! connfd=%d\n", peeraddr.c_str(), channel->fd());
         }
     };
     cli.onMessage = [](const SocketChannelPtr& channel, Buffer* buf) {

--- a/evpp/TcpServer.h
+++ b/evpp/TcpServer.h
@@ -108,9 +108,9 @@ private:
                 server->onWriteComplete(channel, buf);
             }
         };
-        channel->onclose = [server, &channel]() {
+        channel->onclose = [server, &channel](Channel::Status last_status) {
             channel->status = SocketChannel::CLOSED;
-            if (server->onConnection) {
+            if (last_status==SocketChannel::CONNECTED && server->onConnection) {
                 server->onConnection(channel);
             }
             server->removeChannel(channel);


### PR DESCRIPTION
1、TcpClient修正断链无法重连的BUG
2、Channel.onclose增加上一状态，用以区分是正常关闭还是超时重连
