### PR TITLE
fix next_timeout overflow

### DIFF
--- a/event/hevent.h
+++ b/event/hevent.h
@@ -71,7 +71,7 @@ struct htimer_s {
 
 struct htimeout_s {
     HTIMER_FIELDS
-    uint32_t    timeout;                \
+    uint64_t    timeout;                \
 };
 
 struct hperiod_s {

--- a/event/hloop.c
+++ b/event/hloop.c
@@ -76,7 +76,7 @@ static int hloop_process_timers(hloop_t* loop) {
             }
             else if (timer->event_type == HEVENT_TYPE_PERIOD) {
                 hperiod_t* period = (hperiod_t*)timer;
-                timer->next_timeout = cron_next_timeout(period->minute, period->hour, period->day,
+                timer->next_timeout = (uint64_t)cron_next_timeout(period->minute, period->hour, period->day,
                         period->week, period->month) * 1000000;
             }
             heap_insert(&loop->timers, &timer->node);

--- a/event/hloop.c
+++ b/event/hloop.c
@@ -499,7 +499,7 @@ void hidle_del(hidle_t* idle) {
     EVENT_DEL(idle);
 }
 
-htimer_t* htimer_add(hloop_t* loop, htimer_cb cb, uint32_t timeout, uint32_t repeat) {
+htimer_t* htimer_add(hloop_t* loop, htimer_cb cb, uint64_t timeout, uint32_t repeat) {
     if (timeout == 0)   return NULL;
     htimeout_t* timer;
     HV_ALLOC_SIZEOF(timer);

--- a/event/hloop.c
+++ b/event/hloop.c
@@ -71,7 +71,7 @@ static int hloop_process_timers(hloop_t* loop) {
             heap_dequeue(&loop->timers);
             if (timer->event_type == HEVENT_TYPE_TIMEOUT) {
                 while (timer->next_timeout <= now_hrtime) {
-                    timer->next_timeout += ((htimeout_t*)timer)->timeout * 1000;
+                    timer->next_timeout += (uint64_t)((htimeout_t*)timer)->timeout * 1000;
                 }
             }
             else if (timer->event_type == HEVENT_TYPE_PERIOD) {
@@ -550,7 +550,7 @@ htimer_t* htimer_add_period(hloop_t* loop, htimer_cb cb,
     timer->day    = day;
     timer->month  = month;
     timer->week   = week;
-    timer->next_timeout = cron_next_timeout(minute, hour, day, week, month) * 1000000;
+    timer->next_timeout = (uint64_t)cron_next_timeout(minute, hour, day, week, month) * 1000000;
     heap_insert(&loop->timers, &timer->node);
     EVENT_ADD(loop, timer, cb);
     loop->ntimers++;

--- a/event/hloop.h
+++ b/event/hloop.h
@@ -155,7 +155,7 @@ HV_EXPORT void     hidle_del(hidle_t* idle);
 
 // timer
 // @param timeout: unit(ms)
-HV_EXPORT htimer_t* htimer_add(hloop_t* loop, htimer_cb cb, uint32_t timeout, uint32_t repeat DEFAULT(INFINITE));
+HV_EXPORT htimer_t* htimer_add(hloop_t* loop, htimer_cb cb, uint64_t timeout, uint32_t repeat DEFAULT(INFINITE));
 /*
  * minute   hour    day     week    month       cb
  * 0~59     0~23    1~31    0~6     1~12


### PR DESCRIPTION
1、强制转换了两个long乘数为 long long类型；
2、修改了htimeout_s的timeout精度为uint64_t（这样更方便些）
3、修改htimer_add函数的第三个参数类型为uint64_t。
2和3不是必须的，但建议将精度改成一致的，作者可以考虑下~