### PR TITLE
adding raw sockaddr to client address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ Release
 CMakeFiles
 CMakeCache.txt
 cmake_install.cmake
+.idea
+cmake-build-debug

--- a/hconfig.h
+++ b/hconfig.h
@@ -10,7 +10,7 @@
 #endif
 
 #ifndef HAVE_STDATOMIC_H
-#define HAVE_STDATOMIC_H 0
+#define HAVE_STDATOMIC_H 1
 #endif
 
 #ifndef HAVE_SYS_TYPES_H

--- a/http/HttpMessage.h
+++ b/http/HttpMessage.h
@@ -38,6 +38,7 @@
 
 #include "httpdef.h"
 #include "http_content.h"
+#include "hsocket.h"
 
 typedef std::map<std::string, std::string, StringCaseLess>  http_headers;
 typedef std::string                                         http_body;
@@ -45,10 +46,12 @@ typedef std::string                                         http_body;
 struct HNetAddr {
     std::string     ip;
     int             port;
+    sockaddr_u      sockaddr;
 
     std::string ipport() {
         return asprintf("%s:%d", ip.c_str(), port);
     }
+
 };
 
 // Cookie: sessionid=1; domain=.example.com; path=/; max-age=86400; secure; httponly

--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -15,6 +15,7 @@ int HttpHandler::HandleHttpRequest() {
 
     pReq->scheme = ssl ? "https" : "http";
     pReq->client_addr.ip = ip;
+    pReq->client_addr.sockaddr = sockaddr;
     pReq->client_addr.port = port;
     pReq->Host();
     pReq->ParseUrl();

--- a/http/server/HttpHandler.h
+++ b/http/server/HttpHandler.h
@@ -68,6 +68,7 @@ public:
     bool                    ssl;
     char                    ip[64];
     int                     port;
+    sockaddr_u              sockaddr;
 
     // for http
     HttpService             *service;

--- a/http/server/HttpServer.cpp
+++ b/http/server/HttpServer.cpp
@@ -263,7 +263,9 @@ static void on_accept(hio_t* io) {
     // ssl
     handler->ssl = hio_type(io) == HIO_TYPE_SSL;
     // ip
-    sockaddr_ip((sockaddr_u*)hio_peeraddr(io), handler->ip, sizeof(handler->ip));
+    auto addr = (sockaddr_u*)hio_peeraddr(io);
+    sockaddr_ip(addr, handler->ip, sizeof(handler->ip));
+    handler->sockaddr = *addr;
     // port
     handler->port = sockaddr_port((sockaddr_u*)hio_peeraddr(io));
     // service


### PR DESCRIPTION
in some use cases, we need a raw client address, we pack it in binary and we would like to avoid unnecessary parsing of the string