### PR TITLE
docs: fix simple typo, futher -> further

### DIFF
--- a/http/http_parser.h
+++ b/http/http_parser.h
@@ -77,7 +77,7 @@ typedef struct http_parser_settings http_parser_settings;
  * chunked' headers that indicate the presence of a body.
  *
  * Returning `2` from on_headers_complete will tell parser that it should not
- * expect neither a body nor any futher responses on this connection. This is
+ * expect neither a body nor any further responses on this connection. This is
  * useful for handling responses to a CONNECT request which may not contain
  * `Upgrade` or `Connection: upgrade` headers.
  *


### PR DESCRIPTION
There is a small typo in http/http_parser.h.

Should read `further` rather than `futher`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md