### PR TITLE
fixed status_code error and clear write callback in closeFile

### DIFF
--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -292,6 +292,7 @@ int HttpHandler::defaultStaticHandler() {
             }
         }
         else {
+            resp->status_code = HTTP_STATUS_PARTIAL_CONTENT;
             if (service->largeFileHandler) {
                 status_code = customHttpHandler(service->largeFileHandler);
             } else {
@@ -555,4 +556,6 @@ void HttpHandler::closeFile() {
         delete file;
         file = NULL;
     }
+    if(writer)
+        writer->onwrite = NULL;
 }


### PR DESCRIPTION
感谢合并，并完善 #172 
测试中发现几个问题并修复了
1. 对于大文件range请求返回了200
2. 对于keepalive的文件请求因没清理onWrite回调，可能导致一些奇怪的问题