### PR TITLE
设置openssl的'accept moving write buffer'模式

### DIFF
--- a/ssl/openssl.c
+++ b/ssl/openssl.c
@@ -73,6 +73,10 @@ hssl_ctx_t hssl_ctx_new(hssl_ctx_opt_t* param) {
     if (mode == SSL_VERIFY_PEER && !ca_file && !ca_path) {
         SSL_CTX_set_default_verify_paths(ctx);
     }
+
+#ifdef SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER
+    SSL_CTX_set_mode(ctx, SSL_CTX_get_mode(ctx) | SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+#endif
     SSL_CTX_set_verify(ctx, mode, NULL);
     return ctx;
 error:


### PR DESCRIPTION
如果不开启该模式，当调用SSL_write只能写入部分数据时，剩余数据会被复制到hv的队列。稍后再次调用SSL_write写数据时，openssl会检查这次写入操作的buffer地址是否跟上次未完成的写入操作的buffer地址一致，如果不一致就会返回错误，导致连接关闭。开启该模式后，openssl允许两次操作用不同的buffer，但调用者还是确保数据的一致性。详见openssl的文档说明：https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_mode.html