### PR TITLE
[bug fix]: Valgrind report memory leak in main_ctx_init

### DIFF
--- a/base/hmain.c
+++ b/base/hmain.c
@@ -168,7 +168,7 @@ int main_ctx_init(int argc, char** argv) {
     return 0;
 }
 
-int main_ctx_finish() {
+void main_ctx_finish() {
     SAFE_FREE( g_main_ctx.save_argv[ 0 ] );
     SAFE_FREE( g_main_ctx.save_argv );
     SAFE_FREE( g_main_ctx.cmdline );

--- a/base/hmain.c
+++ b/base/hmain.c
@@ -168,6 +168,14 @@ int main_ctx_init(int argc, char** argv) {
     return 0;
 }
 
+int main_ctx_finish() {
+    SAFE_FREE( g_main_ctx.save_argv[ 0 ] );
+    SAFE_FREE( g_main_ctx.save_argv );
+    SAFE_FREE( g_main_ctx.cmdline );
+    SAFE_FREE( g_main_ctx.save_envp[ 0 ] );
+    SAFE_FREE( g_main_ctx.save_envp );
+}
+
 #define UNDEFINED_OPTION    -1
 static int get_arg_type(int short_opt, const char* options) {
     if (options == NULL) return UNDEFINED_OPTION;

--- a/base/hmain.h
+++ b/base/hmain.h
@@ -68,6 +68,8 @@ typedef struct option_s {
 } option_t;
 
 HV_EXPORT int main_ctx_init(int argc, char** argv);
+HV_EXPORT void main_ctx_finish();
+
 // ls -a -l
 // ls -al
 // watch -n 10 ls


### PR DESCRIPTION
Hello!!!

Valgrind report memory leak. When main_ctx_init function is used, is it because are made 5 SAFE_ALLOC in lines 119/120/122/147 and 148. This patch add the main_ctx_finish function to allow to call and free resources in the end of main function.