### PR TITLE
更改hio_close与hio_free的调用关系

### DIFF
--- a/event/hevent.c
+++ b/event/hevent.c
@@ -193,7 +193,6 @@ void hio_done(hio_t* io) {
 
 void hio_free(hio_t* io) {
     if (io == NULL) return;
-    hio_close(io);
     hrecursive_mutex_destroy(&io->write_mutex);
     HV_FREE(io->localaddr);
     HV_FREE(io->peeraddr);

--- a/event/hloop.c
+++ b/event/hloop.c
@@ -356,7 +356,7 @@ static void hloop_cleanup(hloop_t* loop) {
     for (int i = 0; i < loop->ios.maxsize; ++i) {
         hio_t* io = loop->ios.ptr[i];
         if (io) {
-            hio_free(io);
+            hio_close(io);
         }
     }
     io_array_cleanup(&loop->ios);
@@ -744,7 +744,7 @@ void hio_attach(hloop_t* loop, hio_t* io) {
     // so we need to free it if fd exists to avoid memory leak.
     hio_t* preio = loop->ios.ptr[fd];
     if (preio != NULL && preio != io) {
-        hio_free(preio);
+        hio_close(preio);
     }
 
     io->loop = loop;

--- a/event/nio.c
+++ b/event/nio.c
@@ -580,6 +580,7 @@ int hio_close (hio_t* io) {
     if (io->io_type & HIO_TYPE_SOCKET) {
         closesocket(io->fd);
     }
+    hio_free(io);
     return 0;
 }
 #endif


### PR DESCRIPTION
目前创建io时是通过hio_get方式创建，但是在关闭io时候，默认只调用了hio_close，但是hio_close内部并没有释放io本身的内存空间，必须显示调用hio_free才行。
本来应该是hio内部的操作，不应该由用户手动调用hio_free才是。