### PR TITLE
修复宏代码编码错误bug

### DIFF
--- a/base/hplatform.h
+++ b/base/hplatform.h
@@ -282,23 +282,23 @@ typedef double              float64_t;
 typedef int (*method_t)(void* userdata);
 typedef void (*procedure_t)(void* userdata);
 
-#if HAVE_SYS_TYPES_H
+#ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
 
-#if HAVE_SYS_STAT_H
+#ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
 
-#if HAVE_SYS_TIME_H
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>   // for gettimeofday
 #endif
 
-#if HAVE_FCNTL_H
+#ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
 
-#if HAVE_PTHREAD_H
+#ifdef HAVE_PTHREAD_H
 #include <pthread.h>
 #endif
 


### PR DESCRIPTION
在arch64架构的机器上编译时会报宏里#if的错，修改为#ifdef


Signed-off-by: 18819251578 <940901516@qq.com>