### PR TITLE
add mips and mips64 arch define

### DIFF
--- a/base/hplatform.h
+++ b/base/hplatform.h
@@ -55,6 +55,10 @@
     #define ARCH_ARM
 #elif defined(__aarch64__) || defined(__ARM64__)
     #define ARCH_ARM64
+#elif defined(__mips__)
+    #define ARCH_MIPS
+#elif defined(__mips64__)
+    #define ARCH_MIPS64
 #else
     #warning "Untested hardware architecture!"
 #endif


### PR DESCRIPTION
测试MT7628芯片（MIPS架构，OpenWrt操作系统）通过，增加MIPS架构定义，详见[issue](https://github.com/ithewei/libhv/issues/234)
