### PR TITLE
remove assert in hio_set_unpack

### DIFF
--- a/event/hevent.c
+++ b/event/hevent.c
@@ -826,9 +826,6 @@ void hio_set_unpack(hio_t* io, unpack_setting_t* setting) {
         }
     }
     else if (io->unpack_setting->mode == UNPACK_BY_LENGTH_FIELD) {
-        assert(io->unpack_setting->body_offset >=
-               io->unpack_setting->length_field_offset +
-               io->unpack_setting->length_field_bytes);
     }
 
     // NOTE: unpack must have own readbuf


### PR DESCRIPTION
协议报文本身多变，body长度的字段 可能在 body_offset之后。所以这里的assert是不正常的提示。
例如，报文是 [0xff, 0xff, 0x3, 0x2（长度字段）, 0xA]， 前两个字节是head，0x3是类型，0x2是body_len（0x3和0x2两个字节），0xA是校验位
设置时候，body_offset= 2，length_field_offset= 3，length_field_bytes=1， length_adjustment= 1。
这里与assert相悖，所以应该去除assert语句。