### PR TITLE
add -O3 for benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,14 +262,14 @@ webbench: prepare
 	$(CC) -o bin/webbench unittest/webbench.c
 
 echo-servers:
-	$(CXX) -g -Wall -std=c++11 -o bin/pingpong_client echo-servers/pingpong_client.cpp -lhv -pthread
-	$(CC)  -g -Wall -std=c99   -o bin/libevent_echo   echo-servers/libevent_echo.c     -levent
-	$(CC)  -g -Wall -std=c99   -o bin/libev_echo      echo-servers/libev_echo.c        -lev
-	$(CC)  -g -Wall -std=c99   -o bin/libuv_echo      echo-servers/libuv_echo.c        -luv
-	$(CC)  -g -Wall -std=c99   -o bin/libhv_echo      echo-servers/libhv_echo.c        -lhv
-	$(CXX) -g -Wall -std=c++11 -o bin/asio_echo       echo-servers/asio_echo.cpp       -lboost_system -pthread
-	$(CXX) -g -Wall -std=c++11 -o bin/poco_echo       echo-servers/poco_echo.cpp       -lPocoNet -lPocoUtil -lPocoFoundation
-#	$(CXX) -g -Wall -std=c++11 -o bin/muduo_echo      echo-servers/muduo_echo.cpp      -lmuduo_net -lmuduo_base -pthread
+	$(CXX) -g -Wall -std=c++11 -O3 -o bin/pingpong_client echo-servers/pingpong_client.cpp -lhv -pthread
+	$(CC)  -g -Wall -std=c99   -O3 -o bin/libevent_echo   echo-servers/libevent_echo.c     -levent
+	$(CC)  -g -Wall -std=c99   -O3 -o bin/libev_echo      echo-servers/libev_echo.c        -lev
+	$(CC)  -g -Wall -std=c99   -O3 -o bin/libuv_echo      echo-servers/libuv_echo.c        -luv
+	$(CC)  -g -Wall -std=c99   -O3 -o bin/libhv_echo      echo-servers/libhv_echo.c        -lhv
+	$(CXX) -g -Wall -std=c++11 -O3 -o bin/asio_echo       echo-servers/asio_echo.cpp       -lboost_system -pthread
+	$(CXX) -g -Wall -std=c++11 -O3 -o bin/poco_echo       echo-servers/poco_echo.cpp       -lPocoNet -lPocoUtil -lPocoFoundation
+#	$(CXX) -g -Wall -std=c++11 -O3 -o bin/muduo_echo      echo-servers/muduo_echo.cpp      -lmuduo_net -lmuduo_base -pthread
 
 echo-benchmark: echo-servers
 	bash echo-servers/benchmark.sh


### PR DESCRIPTION
不开O3，这不是欺负c++么，实际开O3后，asio略占上风

libevent running on port 2001
libev running on port 2002
libuv running on port 2003
libhv running on port 2004
asio running on port 2005
poco running on port 2006
muduo running on port 2007

==============2001=====================================
Running 10s test @ 127.0.0.1:2001
2 threads and 100 connections, send 1024 bytes each time
total readcount=968263 readbytes=991501312
throughput = 94 MB/s

==============2002=====================================
Running 10s test @ 127.0.0.1:2002
2 threads and 100 connections, send 1024 bytes each time
total readcount=1649179 readbytes=1688759296
throughput = 161 MB/s

==============2003=====================================
Running 10s test @ 127.0.0.1:2003
2 threads and 100 connections, send 1024 bytes each time
total readcount=950052 readbytes=972853248
throughput = 92 MB/s

==============2004=====================================
Running 10s test @ 127.0.0.1:2004
2 threads and 100 connections, send 1024 bytes each time
total readcount=1539447 readbytes=1576393728
throughput = 150 MB/s

==============2005=====================================
Running 10s test @ 127.0.0.1:2005
2 threads and 100 connections, send 1024 bytes each time
total readcount=1572459 readbytes=1610198016
throughput = 153 MB/s

==============2006=====================================
Running 10s test @ 127.0.0.1:2006
2 threads and 100 connections, send 1024 bytes each time
total readcount=1359735 readbytes=1392368640
throughput = 132 MB/s

==============2007=====================================
Running 10s test @ 127.0.0.1:2007
2 threads and 100 connections, send 1024 bytes each time
total readcount=1447975 readbytes=1482726400
throughput = 141 MB/s