### PR TITLE
bugfix: 阻止子进程在 fork() 后绑定端口

### DIFF
--- a/base/hsocket.c
+++ b/base/hsocket.c
@@ -266,7 +266,7 @@ int Bind(int port, const char* host, int type) {
 }
 
 int Listen(int port, const char* host) {
-    int sockfd = Bind(port, host, SOCK_STREAM);
+    int sockfd = Bind(port, host, SOCK_STREAM|SOCK_CLOEXEC);
     if (sockfd < 0) return sockfd;
     return ListenFD(sockfd);
 }


### PR DESCRIPTION
防止从主进程 fork 的子进程继承 libhv 的 socket 端口