### PR TITLE
bugfix: fix for child processes that bind ports after fork() on Linux platforms

### DIFF
--- a/base/hsocket.c
+++ b/base/hsocket.c
@@ -266,7 +266,11 @@ int Bind(int port, const char* host, int type) {
 }
 
 int Listen(int port, const char* host) {
+#ifdef OS_LINUX
+    int sockfd = Bind(port, host, SOCK_STREAM|SOCK_CLOEXEC);
+#else
     int sockfd = Bind(port, host, SOCK_STREAM);
+#endif
     if (sockfd < 0) return sockfd;
     return ListenFD(sockfd);
 }


### PR DESCRIPTION
修复在 linux 平台，通过fork创建的子进程继承 libhv 占有的端口的问题