### PR TITLE
Update Event.h

### DIFF
--- a/evpp/Event.h
+++ b/evpp/Event.h
@@ -12,7 +12,7 @@ struct Event;
 struct Timer;
 
 typedef uint64_t            TimerID;
-#define INVALID_TIMER_ID    ((TimerID)-1)
+#define INVALID_TIMER_ID    ((hv::TimerID)-1)
 
 typedef std::function<void(Event*)>     EventCallback;
 typedef std::function<void(TimerID)>    TimerCallback;


### PR DESCRIPTION
bugfix: 在不使用 hv 命名空间的时候使用 INVALID_TIMER_ID 报错