### PR TITLE
wepoll integration

### DIFF
--- a/3rd/wepoll/CMakeLists.txt
+++ b/3rd/wepoll/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.11)
+project(wepoll)
+include(FetchContent)
+FetchContent_Declare(
+  wepoll
+  URL https://github.com/piscisaureus/wepoll/archive/refs/tags/v1.5.8.zip
+  URL_HASH SHA1=9a145a4cf77af7ed9472859ba08fd34dd6fdd312
+)
+FetchContent_Populate(wepoll)
+add_library(wepoll STATIC "${wepoll_SOURCE_DIR}/wepoll.c" "${wepoll_SOURCE_DIR}/wepoll.h")
+set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/..")
+install(TARGETS wepoll DESTINATION lib)
+install(FILES "${wepoll_SOURCE_DIR}/wepoll.h" DESTINATION include/wepoll)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ endif()
 
 if(WIN32)
     add_definitions(-DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_WARNINGS -D_WIN32_WINNT=0x0600)
-    set(LIBS ${LIBS} winmm iphlpapi ws2_32)
+    set(LIBS ${LIBS} winmm iphlpapi ws2_32 wepoll)
     if(ENABLE_WINDUMP)
         add_definitions(-DENABLE_WINDUMP)
         set(LIBS ${LIBS} dbghelp)

--- a/event/epoll.c
+++ b/event/epoll.c
@@ -5,7 +5,12 @@
 #include "hdef.h"
 #include "hevent.h"
 
+#ifdef OS_WIN
+#include "wepoll/wepoll.h"
+#else
 #include <sys/epoll.h>
+#define epoll_close close
+#endif
 
 #include "array.h"
 #define EVENTS_INIT_SIZE    64
@@ -29,7 +34,7 @@ int iowatcher_init(hloop_t* loop) {
 int iowatcher_cleanup(hloop_t* loop) {
     if (loop->iowatcher == NULL) return 0;
     epoll_ctx_t* epoll_ctx = (epoll_ctx_t*)loop->iowatcher;
-    close(epoll_ctx->epfd);
+    epoll_close(epoll_ctx->epfd);
     events_cleanup(&epoll_ctx->events);
     HV_FREE(loop->iowatcher);
     return 0;

--- a/event/iowatcher.h
+++ b/event/iowatcher.h
@@ -12,8 +12,8 @@
     !defined(EVENT_PORT) &&     \
     !defined(EVENT_NOEVENT)
 #ifdef OS_WIN
-// #define EVENT_IOCP // IOCP improving
-#define EVENT_POLL
+//wepoll
+#define EVENT_EPOLL
 #elif defined(OS_LINUX)
 #define EVENT_EPOLL
 #elif defined(OS_MAC)


### PR DESCRIPTION
`wepoll` library provides epoll-like interface for Windows IOCP.

`3rd/wepoll/CMakeLists.txt` is sample cmake script which downloads wepoll sources, builds static library and installs it to `3rd/lib/wepoll.lib`, also installs `wepoll.h` to `3rd/wepoll/wepoll.h`.
