### PR TITLE
fixbug: EventLoopThread::stop cannot end when loop_thread is destroyed when app exited

### DIFF
--- a/evpp/EventLoopThread.h
+++ b/evpp/EventLoopThread.h
@@ -66,9 +66,7 @@ public:
 
         if (wait_thread_stopped) {
             if (hv_gettid() == loop_tid) return;
-            while (!isStopped()) {
-                hv_delay(1);
-            }
+            join();
         }
     }
 


### PR DESCRIPTION
Issue: when AsyncHttpClient is destructed at APP exiting time, the EventLoopThread status is freezing as Stopping. So the loop waiting the Stopped status can not exit. Solution: when stop the EventLoopThead, waiting the thread-object exit instead of waiting the Stopped status.