### PR TITLE
fix #425

### DIFF
--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -498,7 +498,7 @@ int HttpHandler::defaultStaticHandler() {
     std::string path = req->Path();
     const char* req_path = path.c_str();
     // path safe check
-    if (req_path[0] != '/' || strstr(req_path, "/../")) {
+    if (req_path[0] != '/' || strstr(req_path, "/..") || strstr(req_path, "\\..")) {
         return HTTP_STATUS_BAD_REQUEST;
     }
 


### PR DESCRIPTION
请求路径为带"\"，例如http://127.0.0.1/..\..\..\..\..\..\..\..\..\..\windows\win.ini时，http服务存在越权漏洞 