### PR TITLE
fix linux gcc4.8.5 warning:提领类型双关的指针将破坏强重叠规则

### DIFF
--- a/http/wsdef.h
+++ b/http/wsdef.h
@@ -63,8 +63,12 @@ HV_INLINE int ws_client_build_frame(
     /* bool has_mask = true */
     enum ws_opcode opcode DEFAULT(WS_OPCODE_TEXT),
     bool fin DEFAULT(true)) {
-    char mask[4];
-    *(int*)mask = rand();
+    char mask[4] = {0};
+    int i = 0;
+    int imask = rand();
+    for (i = 0; i < 4; i++) {
+        mask[i] = (imask >> (8 * i)) & 0xff;
+    }
     return ws_build_frame(out, data, data_len, mask, true, opcode, fin);
 }
 


### PR DESCRIPTION
#435