### PR TITLE
fix colored log line break "\n" position

### DIFF
--- a/base/hlog.c
+++ b/base/hlog.c
@@ -419,7 +419,8 @@ int logger_print(logger_t* logger, int level, const char* fmt, ...) {
         len += snprintf(buf + len, bufsize - len, "%s", CLR_CLR "\n");
     }
     else {
-        len += snprintf(buf + len, bufsize - len, "%s", "\n");
+        if(len<bufsize) {
+            buf[len++] = '\n';
     }
 
     if (logger->handler) {

--- a/base/hlog.c
+++ b/base/hlog.c
@@ -416,7 +416,10 @@ int logger_print(logger_t* logger, int level, const char* fmt, ...) {
     }
 
     if (logger->enable_color) {
-        len += snprintf(buf + len, bufsize - len, "%s", CLR_CLR);
+        len += snprintf(buf + len, bufsize - len, "%s", CLR_CLR "\n");
+    }
+    else {
+        len += snprintf(buf + len, bufsize - len, "%s", "\n");
     }
 
     if (logger->handler) {

--- a/base/hlog.c
+++ b/base/hlog.c
@@ -416,12 +416,11 @@ int logger_print(logger_t* logger, int level, const char* fmt, ...) {
     }
 
     if (logger->enable_color) {
-        len += snprintf(buf + len, bufsize - len, "%s", CLR_CLR "\n");
+        len += snprintf(buf + len, bufsize - len, "%s", CLR_CLR);
     }
-    else {
-        if(len<bufsize) {
-            buf[len++] = '\n';
-        }
+
+    if(len<bufsize) {
+        buf[len++] = '\n';
     }
 
     if (logger->handler) {

--- a/base/hlog.c
+++ b/base/hlog.c
@@ -421,6 +421,7 @@ int logger_print(logger_t* logger, int level, const char* fmt, ...) {
     else {
         if(len<bufsize) {
             buf[len++] = '\n';
+        }
     }
 
     if (logger->handler) {

--- a/base/hlog.h
+++ b/base/hlog.h
@@ -138,11 +138,11 @@ HV_EXPORT void      hv_destroy_default_logger(void);
 #define hlog_fsync()                    logger_fsync(hlog)
 #define hlog_get_cur_file()             logger_get_cur_file(hlog)
 
-#define hlogd(fmt, ...) logger_print(hlog, LOG_LEVEL_DEBUG, fmt " [%s:%d:%s]\n", ## __VA_ARGS__, __FILENAME__, __LINE__, __FUNCTION__)
-#define hlogi(fmt, ...) logger_print(hlog, LOG_LEVEL_INFO,  fmt " [%s:%d:%s]\n", ## __VA_ARGS__, __FILENAME__, __LINE__, __FUNCTION__)
-#define hlogw(fmt, ...) logger_print(hlog, LOG_LEVEL_WARN,  fmt " [%s:%d:%s]\n", ## __VA_ARGS__, __FILENAME__, __LINE__, __FUNCTION__)
-#define hloge(fmt, ...) logger_print(hlog, LOG_LEVEL_ERROR, fmt " [%s:%d:%s]\n", ## __VA_ARGS__, __FILENAME__, __LINE__, __FUNCTION__)
-#define hlogf(fmt, ...) logger_print(hlog, LOG_LEVEL_FATAL, fmt " [%s:%d:%s]\n", ## __VA_ARGS__, __FILENAME__, __LINE__, __FUNCTION__)
+#define hlogd(fmt, ...) logger_print(hlog, LOG_LEVEL_DEBUG, fmt " [%s:%d:%s]", ## __VA_ARGS__, __FILENAME__, __LINE__, __FUNCTION__)
+#define hlogi(fmt, ...) logger_print(hlog, LOG_LEVEL_INFO,  fmt " [%s:%d:%s]", ## __VA_ARGS__, __FILENAME__, __LINE__, __FUNCTION__)
+#define hlogw(fmt, ...) logger_print(hlog, LOG_LEVEL_WARN,  fmt " [%s:%d:%s]", ## __VA_ARGS__, __FILENAME__, __LINE__, __FUNCTION__)
+#define hloge(fmt, ...) logger_print(hlog, LOG_LEVEL_ERROR, fmt " [%s:%d:%s]", ## __VA_ARGS__, __FILENAME__, __LINE__, __FUNCTION__)
+#define hlogf(fmt, ...) logger_print(hlog, LOG_LEVEL_FATAL, fmt " [%s:%d:%s]", ## __VA_ARGS__, __FILENAME__, __LINE__, __FUNCTION__)
 
 // below for android
 #if defined(ANDROID) || defined(__ANDROID__)


### PR DESCRIPTION
当前在带色彩日志输出时，换行符号 “\n” 在 CLR_CLR 之前；因此在输出“FATAL”级别那种红底白字日志时，会导致下一行背景同样为红色；影响美观。
