### PR TITLE
unix平台SOCKET与libpcap重定义

### DIFF
--- a/base/hsocket.h
+++ b/base/hsocket.h
@@ -66,7 +66,9 @@ HV_INLINE int nonblocking(int sockfd) {
 #define blocking(s)     fcntl(s, F_SETFL, fcntl(s, F_GETFL) & ~O_NONBLOCK)
 #define nonblocking(s)  fcntl(s, F_SETFL, fcntl(s, F_GETFL) |  O_NONBLOCK)
 
-typedef int         SOCKET;
+#ifndef SOCKET
+#define SOCKET int
+#endif
 #define INVALID_SOCKET  -1
 
 HV_INLINE int closesocket(int sockfd) {


### PR DESCRIPTION
在<https://github.com/the-tcpdump-group/libpcap/blob/master/pcap/socket.h>第70行
```c
  /*!
   * \brief In Winsock, a socket handle is of type SOCKET; in UN*X, it's
   * a file descriptor, and therefore a signed integer.
   * We define SOCKET to be a signed integer on UN*X, so that it can
   * be used on both platforms.
   */
  #ifndef SOCKET
    #define SOCKET int
  #endif
```