### PR TITLE
修复kv值切割bug

### DIFF
--- a/cpputil/hstring.cpp
+++ b/cpputil/hstring.cpp
@@ -131,7 +131,7 @@ hv::KeyValue splitKV(const std::string& str, char kv_kv, char k_v) {
             state = s_key;
             key = p+1;
         }
-        else if (*p == k_v) {
+        else if (*p == k_v && state != s_value) {
             state = s_value;
             value = p+1;
         }


### PR DESCRIPTION
如果string为`url=http://127.0.0.1?token=12345&name=test`

方法`splitKV(string, ',', '=')`的分割结果不正确: `url=test`