### PR TITLE
mqtt_client.h: add missing `<string>` include for `gcc-13`

### DIFF
--- a/mqtt/mqtt_client.h
+++ b/mqtt/mqtt_client.h
@@ -131,6 +131,7 @@ END_EXTERN_C
 #include <functional>
 #include <map>
 #include <mutex>
+#include <string>
 
 namespace hv {
 


### PR DESCRIPTION
Without the change build on `gcc-13` fails as:

    [ 98%] Built target hmain_test
    In file included from /build/source/examples/mqtt/mqtt_client_test.cpp:10:
    /build/source/examples/../mqtt/mqtt_client.h: In member function 'int hv::MqttClient::publish(const std::string&, const std::string&, int, int, MqttCallback)':
    /build/source/examples/../mqtt/mqtt_client.h:232:25: error: invalid use of incomplete type 'const std::string' {aka 'const class std::__cxx11::basic_string<char>'}
      232 |         msg.topic_len = topic.size();
          |                         ^~~~~