### PR TITLE
httphandler.cpp: fix if-none-match header misspell (#492)

### DIFF
--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -604,7 +604,7 @@ int HttpHandler::defaultStaticHandler() {
     }
     else {
         // Not Modified
-        auto iter = req->headers.find("if-not-match");
+        auto iter = req->headers.find("if-none-match");
         if (iter != req->headers.end() &&
             strcmp(iter->second.c_str(), fc->etag) == 0) {
             fc = NULL;


### PR DESCRIPTION
fix header if-none-match misspell in the HttpHandler.cpp