### PR TITLE
Add Bazel Build Support for libhv

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,24 @@
+build --copt=-std=c99
+build --cxxopt=-std=c++11
+build --define BUILD_SHARED=ON
+build --define BUILD_STATIC=ON
+build --define BUILD_EXAMPLES=ON
+build --define BUILD_UNITTEST=OFF
+build --define WITH_PROTOCOL=OFF
+build --define WITH_EVPP=ON
+build --define WITH_HTTP=ON
+build --define WITH_HTTP_SERVER=ON
+build --define WITH_HTTP_CLIENT=ON
+build --define WITH_MQTT=OFF
+build --define ENABLE_UDS=OFF
+build --define USE_MULTIMAP=OFF
+build --define WITH_CURL=OFF
+build --define WITH_NGHTTP2=OFF
+build --define WITH_OPENSSL=OFF
+build --define WITH_GNUTLS=OFF
+build --define WITH_MBEDTLS=OFF
+build --define WITH_KCP=OFF
+build --define WITH_WEPOLL=ON
+build --define ENABLE_WINDUMP=OFF
+build --define BUILD_FOR_MT=OFF
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Bazel
+bazel-*
+MODULE.bazel
+MODULE.bazel.lock
+
 # Compiled Object files
 *.o
 *.lo

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,466 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+
+config_setting(
+    name = "ios",
+    constraint_values = ["@platforms//apple:ios"],
+)
+
+config_setting(
+    name = "msvc",
+    values = {
+        "compiler": "msvc-cl",
+    },
+)
+
+config_setting(
+    name = "debug",
+    values = {"compilation_mode": "dbg"},
+)
+
+config_setting(
+    name = "release",
+    values = {"compilation_mode": "opt"},
+)
+
+config_setting(
+    name = "build_shared",
+    define_values = {"BUILD_SHARED": "ON"},
+)
+
+config_setting(
+    name = "build_static",
+    define_values = {"BUILD_STATIC": "ON"}
+)
+
+config_setting(
+    name = "build_examples",
+    define_values = {"BUILD_EXAMPLES": "ON"},
+)
+
+config_setting(
+    name = "build_unittest",
+    define_values = {"BUILD_UNITTEST": "ON"}
+)
+
+config_setting(
+    name = "with_protocol",
+    define_values = {"WITH_PROTOCOL": "ON"}
+)
+
+config_setting(
+    name = "with_evpp",
+    define_values = {
+        "WITH_EVPP": "ON",
+    },
+    visibility = [":__subpackages__"]
+)
+
+config_setting(
+    name = "with_http",
+    define_values = {
+        "WITH_EVPP": "ON",
+        "WITH_HTTP": "ON",
+    },
+    visibility = [":__subpackages__"]
+)
+
+config_setting(
+    name = "with_http_server",
+    define_values = {
+        "WITH_EVPP": "ON",
+        "WITH_HTTP": "ON",
+        "WITH_HTTP_SERVER": "ON",
+    },
+    visibility = [":__subpackages__"]
+)
+
+config_setting(
+    name = "with_http_client",
+    define_values = {
+        "WITH_EVPP": "ON",
+        "WITH_HTTP": "ON",
+        "WITH_HTTP_CLIENT": "ON",
+    },
+    visibility = [":__subpackages__"]
+)
+
+config_setting(
+    name = "with_evpp_nghttp2",
+    define_values = {
+        "WITH_EVPP": "ON",
+        "WITH_HTTP": "ON",
+        "WITH_NGHTTP2": "ON",
+    }
+)
+
+config_setting(
+    name = "with_mqtt",
+    define_values = {"WITH_MQTT": "ON"},
+    visibility = [":__subpackages__"],
+)
+
+config_setting(
+    name = "enable_uds",
+    define_values = {"ENABLE_UDS": "ON"}
+)
+
+config_setting(
+    name = "use_multimap",
+    define_values = {"USE_MULTIMAP": "ON"}
+)
+
+config_setting(
+    name = "with_curl",
+    define_values = {"WITH_CURL": "ON"}
+)
+
+config_setting(
+    name = "with_nghttp2",
+    define_values = {"WITH_NGHTTP2": "ON"}
+)
+
+config_setting(
+    name = "with_openssl",
+    define_values = {"WITH_OPENSSL": "ON"}
+)
+
+config_setting(
+    name = "with_gnutls",
+    define_values = {"WITH_GNUTLS": "ON"}
+)
+
+config_setting(
+    name = "with_mbedtls",
+    define_values = {"WITH_MBEDTLS": "ON"}
+)
+
+config_setting(
+    name = "with_kcp",
+    define_values = {"WITH_KCP": "ON"}
+)
+
+config_setting(
+    name = "with_wepoll",
+    constraint_values = ["@platforms//os:windows"],
+    define_values = {"WITH_WEPOLL": "ON"}
+)
+
+config_setting(
+    name = "enable_windump",
+    constraint_values = ["@platforms//os:windows"],
+    define_values = {"ENABLE_WINDUMP": "ON"}
+)
+
+config_setting(
+    name = "build_for_mt_dbg",
+    constraint_values = ["@platforms//os:windows"],
+    define_values = {
+        "BUILD_FOR_MT": "ON",
+        "compilation_mode": "dbg"
+    }
+)
+
+config_setting(
+    name = "build_for_mt_opt",
+    constraint_values = ["@platforms//os:windows"],
+    define_values = {
+        "BUILD_FOR_MT": "ON",
+        "compilation_mode": "opt"
+    }
+)
+
+genrule(
+    name = "config",
+    outs = ["hconfig.h"],
+    cmd = "($(execpath configure) && cp hconfig.h $@) || exit 1",
+    tools = ["configure"],
+)
+
+HEADERS_DIRS = ["base", "ssl", "event"] + select({
+    "with_wepoll": ["event/wepoll"],
+    "//conditions:default": [],
+}) + select({
+    "with_kcp": ["event/kcp"],
+    "//conditions:default": [],
+}) + ["util"] + select({
+    "with_protocol": ["protocol"],
+    "//conditions:default": [],
+}) + select({
+    "with_evpp": ["cpputil", "evpp"],
+    "//conditions:default": [],
+}) + select({
+    "with_http": ["http"],
+    "//conditions:default": [],
+}) + select({
+    "with_http_server": ["http/server"],
+    "//conditions:default": [],
+}) + select({
+    "with_http_client": ["http/client"],
+    "//conditions:default": [],
+}) + select({
+    "with_mqtt": ["mqtt"],
+    "//conditions:default": [],
+})
+
+COPTS = select({
+    "debug": ["-DDEBUG"],
+    "release": ["-DNDEBUG"],
+    "//conditions:default": [],
+}) + select({
+    "enable_uds": ["-DENABLE_UDS"],
+    "//conditions:default": [],
+}) + select({
+    "use_multimap": ["-DUSE_MULTIMAP"],
+    "//conditions:default": [],
+}) + select({
+    "with_curl": ["-DWITH_CURL"],
+    "//conditions:default": [],
+}) + select({
+    "with_nghttp2": ["-DWITH_NGHTTP2"],
+    "//conditions:default": [],
+}) + select({
+    "with_openssl": ["-DWITH_OPENSSL"],
+    "//conditions:default": [],
+}) + select({
+    "with_gnutls": ["-DWITH_GNUTLS"],
+    "//conditions:default": [],
+}) + select({
+    "with_mbedtls": ["-DWITH_MBEDTLS"],
+    "//conditions:default": [],
+}) + select({
+    "@platforms//os:windows": ["-DWIN32_LEAN_AND_MEAN", "-D_CRT_SECURE_NO_WARNINGS", "-D_WIN32_WINNT=0x0600"],
+    "//conditions:default": [],
+}) + select({
+    "enable_windump": ["-DENABLE_WINDUMP"],
+    "//conditions:default": [],
+}) + select({
+    "build_for_mt_dbg": ["/MTd"],
+    "build_for_mt_opt": ["/MT"],
+    "//conditions:default": [],
+})
+
+LINKOPTS = select({
+    "msvc": [],
+    "//conditions:default": ["-pthread"],
+}) + select({
+    "@platforms//os:linux": [
+        "-lpthread",
+        "-lm",
+        "-ldl",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@bazel_tools//tools/cpp:gcc": ["-lrt"],
+    "//conditions:default": [],
+})
+
+BASE_HEADERS = [
+    "base/hplatform.h",
+    "base/hdef.h",
+    "base/hatomic.h",
+    "base/herr.h",
+    "base/htime.h",
+    "base/hmath.h",
+    "base/hbase.h",
+    "base/hversion.h",
+    "base/hsysinfo.h",
+    "base/hproc.h",
+    "base/hthread.h",
+    "base/hmutex.h",
+    "base/hsocket.h",
+    "base/hlog.h",
+    "base/hbuf.h",
+    "base/hmain.h",
+    "base/hendian.h",
+]
+
+SSL_HEADERS = [
+    "ssl/hssl.h",
+]
+
+EVENT_HEADERS = [
+    "event/hloop.h",
+    "event/nlog.h",
+]
+
+UTIL_HEADERS = [
+    "util/base64.h",
+    "util/md5.h",
+    "util/sha1.h",
+]
+
+CPPUTIL_HEADERS = [
+    "cpputil/hmap.h",
+    "cpputil/hstring.h",
+    "cpputil/hfile.h",
+    "cpputil/hpath.h",
+    "cpputil/hdir.h",
+    "cpputil/hurl.h",
+    "cpputil/hscope.h",
+    "cpputil/hthreadpool.h",
+    "cpputil/hasync.h",
+    "cpputil/hobjectpool.h",
+    "cpputil/ifconfig.h",
+    "cpputil/iniparser.h",
+    "cpputil/json.hpp",
+    "cpputil/singleton.h",
+    "cpputil/ThreadLocalStorage.h",
+]
+
+EVPP_HEADERS = [
+    "evpp/Buffer.h",
+    "evpp/Channel.h",
+    "evpp/Event.h",
+    "evpp/EventLoop.h",
+    "evpp/EventLoopThread.h",
+    "evpp/EventLoopThreadPool.h",
+    "evpp/Status.h",
+    "evpp/TcpClient.h",
+    "evpp/TcpServer.h",
+    "evpp/UdpClient.h",
+    "evpp/UdpServer.h",
+]
+
+PROTOCOL_HEADERS = [
+    "protocol/icmp.h",
+    "protocol/dns.h",
+    "protocol/ftp.h",
+    "protocol/smtp.h",
+]
+
+HTTP_HEADERS = [
+    "http/httpdef.h",
+    "http/wsdef.h",
+    "http/http_content.h",
+    "http/HttpMessage.h",
+    "http/HttpParser.h",
+    "http/WebSocketParser.h",
+    "http/WebSocketChannel.h",
+]
+
+HTTP2_HEADERS = [
+    "http/http2def.h",
+    "http/grpcdef.h",
+]
+
+HTTP_CLIENT_HEADERS = [
+    "http/client/HttpClient.h",
+    "http/client/requests.h",
+    "http/client/axios.h",
+    "http/client/AsyncHttpClient.h",
+    "http/client/WebSocketClient.h",
+]
+
+HTTP_SERVER_HEADERS = [
+    "http/server/HttpServer.h",
+    "http/server/HttpService.h",
+    "http/server/HttpContext.h",
+    "http/server/HttpResponseWriter.h",
+    "http/server/WebSocketServer.h",
+]
+
+MQTT_HEADERS = [
+    "mqtt/mqtt_protocol.h",
+    "mqtt/mqtt_client.h",
+]
+
+
+HEADERS = ["hv.h", ":config", "hexport.h"] + BASE_HEADERS + SSL_HEADERS + EVENT_HEADERS + UTIL_HEADERS + select({
+    "with_protocol": PROTOCOL_HEADERS,
+    "//conditions:default": [],
+}) + select({
+    "with_evpp": CPPUTIL_HEADERS + EVPP_HEADERS,
+    "//conditions:default": [],
+}) + select({
+    "with_http": HTTP_HEADERS,
+    "//conditions:default": [],
+}) + select({
+    "with_evpp_nghttp2": HTTP2_HEADERS,
+    "//conditions:default": [],
+}) + select({
+    "with_http_server": HTTP_SERVER_HEADERS,
+    "//conditions:default": [],
+}) + select({
+    "with_http_client": HTTP_CLIENT_HEADERS,
+    "//conditions:default": [],
+}) + select({
+    "with_mqtt": MQTT_HEADERS,
+    "//conditions:default": [],
+})
+
+
+CORE_SRCS = glob(
+    ["*.h"], exclude = ["*_test.c"]
+) + glob(
+    ["base/*.h", "base/*.c", "base/*.cpp"], exclude = ["base/*_test.c"]
+) + glob(
+    ["ssl/*.h", "ssl/*.c", "ssl/*.cpp"], exclude = ["ssl/*_test.c"]
+) + glob(
+    ["event/*.h", "event/*.c", "event/*.cpp"], exclude = ["event/*_test.c"]
+) + select({
+    "with_wepoll": glob(["event/wepoll/*.h", "event/wepoll/*.c", "event/wepoll/*.cpp"], exclude = ["event/wepoll/*_test.c"]),
+    "//conditions:default": [],
+}) + select({
+    "with_kcp": glob(["event/kcp/*.h", "event/kcp/*.c", "event/kcp/*.cpp"], exclude = ["event/kcp/*_test.c"]),
+    "//conditions:default": [],
+})
+
+SRCS = CORE_SRCS + glob(["util/*.h", "util/*.c", "util/*.cpp"], exclude = ["util/*_test.c"]) + select({
+    "with_protocol": glob(["protocol/*.h", "protocol/*.c", "protocol/*.cpp"], exclude = ["protocol/*_test.c"]),
+    "//conditions:default": [],
+}) + select({
+    "with_evpp": glob(["cpputil/*.h", "cpputil/*.c", "cpputil/*.cpp", "evpp/*.h", "evpp/*.c", "evpp/*.cpp"], exclude = ["cpputil/*_test.c", "evpp/*_test.c", "evpp/*_test.cpp"]),
+    "//conditions:default": [],
+}) + select({
+    "with_http": glob(["http/*.h", "http/*.c", "http/*.cpp"], exclude = ["http/*_test.c"]),
+    "//conditions:default": [],
+}) + select({
+    "with_http_server": glob(["http/server/*.h", "http/server/*.c", "http/server/*.cpp"], exclude = ["http/server/*_test.c"]),
+    "//conditions:default": [],
+}) + select({
+    "with_http_client": glob(["http/client/*.h", "http/client/*.c", "http/client/*.cpp"], exclude = ["http/client/*_test.c"]),
+    "//conditions:default": [],
+}) + select({
+    "with_mqtt": glob(["mqtt/*.h", "mqtt/*.c", "mqtt/*.cpp"], exclude = ["mqtt/*_test.c"]),
+    "//conditions:default": [],
+})
+
+cc_library(
+    name = "hv_static",
+    srcs = SRCS,
+    hdrs = HEADERS,
+    includes = HEADERS_DIRS,
+    defines = ["HV_STATICLIB"],
+    copts = COPTS,
+    linkstatic = True,
+    linkopts = LINKOPTS,
+)
+
+
+cc_library(
+    name = "hv",
+    srcs = SRCS,
+    hdrs = HEADERS,
+    includes = HEADERS_DIRS,
+    defines = ["HV_DYNAMICLIB"],
+    copts = COPTS,
+    linkopts = LINKOPTS,
+    visibility = ["//visibility:public"]
+)
+
+filegroup(
+    name = "libhv",
+    srcs = select({
+        "build_shared": [":hv"],
+        "//conditions:default": [],
+    }) + select({
+        "build_static": [":hv_static"],
+        "//conditions:default": [],
+    })  + select({
+        "build_examples": ["//examples:examples"],
+        "//conditions:default": [],
+    })
+)
+
+

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,1 @@
+workspace(name = "hv")

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,0 +1,226 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+cc_binary(
+    name = "hloop_test",
+    srcs = ["hloop_test.c"],
+    deps = ["//:hv"]
+)
+
+
+cc_binary(
+    name = "htimer_test",
+    srcs = ["htimer_test.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "nc",
+    srcs = ["nc.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "tinyhttpd",
+    srcs = ["tinyhttpd.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "tinyproxyd",
+    srcs = ["tinyproxyd.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "tcp_client_test",
+    srcs = ["tcp_client_test.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "tcp_echo_server",
+    srcs = ["tcp_echo_server.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "tcp_chat_server",
+    srcs = ["tcp_chat_server.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "tcp_proxy_server",
+    srcs = ["tcp_proxy_server.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "udp_echo_server",
+    srcs = ["udp_echo_server.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "udp_proxy_server",
+    srcs = ["udp_proxy_server.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "socks5_proxy_server",
+    srcs = ["socks5_proxy_server.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "jsonrpc_client",
+    srcs = ["jsonrpc/jsonrpc_client.c", "jsonrpc/cJSON.c"] + glob(["jsonrpc/*.h"]),
+    copts = ["-DCJSON_HIDE_SYMBOLS"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "jsonrpc_server",
+    srcs = ["jsonrpc/jsonrpc_server.c", "jsonrpc/cJSON.c"] + glob(["jsonrpc/*.h"]),
+    copts = ["-DCJSON_HIDE_SYMBOLS"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "hmain_test",
+    srcs = ["hmain_test.cpp"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "nmap",
+    srcs = glob(["nmap/*"]),
+    copts = ["-DPRINT_DEBUG"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "wrk",
+    srcs = ["wrk.cpp"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "http_server_test",
+    srcs = ["http_server_test.cpp"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "websocket_server_test",
+    srcs = ["websocket_server_test.cpp"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "curl",
+    srcs = ["curl.cpp"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "wget",
+    srcs = ["wget.cpp"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "consul",
+    srcs = glob(["consul/*"]),
+    copts = ["-DPRINT_DEBUG"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "http_client_test",
+    srcs = ["http_client_test.cpp"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "websocket_client_test",
+    srcs = ["websocket_client_test.cpp"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "httpd",
+    srcs = glob(["httpd/*"]),
+    copts = ["-DPRINT_DEBUG"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "mqtt_sub",
+    srcs = ["mqtt/mqtt_sub.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "mqtt_pub",
+    srcs = ["mqtt/mqtt_pub.c"],
+    deps = ["//:hv"]
+)
+
+cc_binary(
+    name = "mqtt_client_test",
+    srcs = ["mqtt/mqtt_client_test.cpp"],
+    deps = ["//:hv"]
+)
+
+config_setting(
+    name = "with_http_server_client",
+    define_values = {
+        "WITH_EVPP": "ON",
+        "WITH_HTTP": "ON",
+        "WITH_HTTP_SERVER": "ON",
+        "WITH_HTTP_CLIENT": "ON",
+    },
+)
+
+
+filegroup(
+    name = "examples",
+    srcs = [
+        ":hloop_test",
+        ":htimer_test",
+        ":nc",
+        ":tinyhttpd",
+        ":tinyproxyd",
+        ":tcp_client_test",
+        ":tcp_echo_server",
+        ":tcp_chat_server",
+        ":tcp_proxy_server",
+        ":udp_echo_server",
+        ":udp_proxy_server",
+        ":socks5_proxy_server",
+        ":jsonrpc_client",
+        ":jsonrpc_server",
+    ] + select({
+        "//:with_evpp": [":hmain_test", ":nmap"],
+        "//conditions:default": [],
+    }) + select({
+        "//:with_http": [":wrk"],
+        "//conditions:default": [],
+    }) + select({
+        "//:with_http_server": [":http_server_test", ":websocket_server_test"],
+        "//conditions:default": [],
+    }) + select({
+        "//:with_http_client": [":curl", ":wget", ":consul", ":http_client_test", ":websocket_client_test"],
+        "//conditions:default": [],
+    }) + select({
+        "with_http_server_client": [":httpd"],
+        "//conditions:default": [],
+    }) + select({
+        "//:with_mqtt": ["mqtt_sub", "mqtt_pub", "mqtt_client_test"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//:__pkg__"]
+)
+


### PR DESCRIPTION
This pull request adds support for building libhv using the Bazel build system. Bazel offers several advantages over traditional build systems like Make and CMake, such as incremental builds and simpler usage.

## Changes
- Added Bazel BUILD files for building libhv and its examples
- Created a demo project that demonstrates how to use libhv with Bazel (https://github.com/Edward-Elric233/libhv-bazel-test)

## Limitations and Future Work
The current implementation provides basic support for building libhv with Bazel on Linux, but there are a few known limitations:
1. Header file paths: The current implementation requires users to include libhv headers without the hv/ prefix, which differs from the Make/CMake builds. This is due to a limitation in Bazel's cc_library rule, which requires internal and external header paths to be the same. I am open to suggestions for better ways to address this issue.
2. Platform support: The current implementation relies on the configure script to generate hconfig.h, which limits the build to bash environments. This means that on Windows, libhv can only be built using Bazel within the Windows Subsystem for Linux (WSL).
3. Dependency management: The current implementation does not yet fully support managing dependencies on other libraries.

In the future, I intend to investigate better solutions for header file paths, expand platform support to enable native Windows builds, and implement full dependency management for external libraries.

I welcome feedback and contributions to further improve Bazel support for libhv.

Closes #506
