### PR TITLE
Add support for CPack, allowing easy creation of RPM and DEB packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,3 +279,24 @@ endif()
 if(BUILD_UNITTEST)
     add_subdirectory(unittest)
 endif()
+
+# CPack settings
+set(CPACK_PACKAGE_NAME "libhv")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_RELEASE 1)
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A high-performance C/C++ network library")
+set(CPACK_PACKAGE_VENDOR "libhv")
+set(CPACK_PACKAGE_CONTACT "ithewei <ithewei@163.com>")
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_HOST_SYSTEM_PROCESSOR}")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+
+# Specify the package generators
+set(CPACK_GENERATOR "TGZ;DEB;RPM")
+
+# Enable CPack debug output
+set(CPACK_PACKAGE_DEBUG True)
+
+# https://cmake.org/cmake/help/latest/variable/CPACK_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION.html
+set(CPACK_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION "ON")
+include(CPack)


### PR DESCRIPTION
I have been considering manually packaging libhv into RPM and DEB packages for a while. Recently, due to work requirements, I learned about the [Infinity project](https://github.com/infiniflow/infinity) and discovered that CMake can directly use CPack for packaging. By adding just a few descriptive statements in the CMakeLists.txt file, RPM, DEB, and TGZ packages can be generated in the build directory by executing the `cpack` command. These packages can be placed in the Release section, allowing users to install and use libhv easily through their package manager, eliminating the need for manual compilation.

```bash
$ mkdir build
$ cd build
$ cmake ..
$ cmake --build .
$ cpack
$ ls libhv-*
libhv-1.0.0-x86_64.deb  libhv-1.0.0-x86_64.rpm  libhv-1.0.0-x86_64.tar.gz
```

Users can download the packages. For example, on Fedora/RHEL/CentOS/OpenSUSE systems:

```bash
wget https://github.com/Edward-Elric233/libhv/releases/download/v1.3.3/libhv-1.0.0-x86_64.rpm
sudo rpm -ivh libhv-1.0.0-x86_64.rpm
```

After installation, users can utilize the libhv headers and libraries for development.

I would be sincerely grateful if you could review this PR and provide any feedback or suggestions for improvement.  Thank you for your time and attention.