### PR TITLE
lmj010308 fixed /http/server/HttpResponseWriter.cpp 使用SSEvent时,当event 为空指针时，不加event参数

### DIFF
--- a/http/server/HttpResponseWriter.cpp
+++ b/http/server/HttpResponseWriter.cpp
@@ -67,8 +67,10 @@ int HttpResponseWriter::SSEvent(const std::string& data, const char* event /* = 
     if (state == SEND_BEGIN) {
         EndHeaders("Content-Type", "text/event-stream");
     }
-    std::string msg;
-    msg =  "event: "; msg += event; msg += "\n";
+    std::string msg="";
+    if(event != nullptr){
+      msg =  "event: "; msg += event; msg += "\n";
+    }
     msg += "data: ";  msg += data;  msg += "\n\n";
     state = SEND_BODY;
     return write(msg);


### PR DESCRIPTION
int HttpResponseWriter::SSEvent(const std::string& data, const char* event /* = "message" */) {
    if (state == SEND_BEGIN) {
        EndHeaders("Content-Type", "text/event-stream");
    }
    std::string msg="";
    if(event != nullptr){
      msg =  "event: "; msg += event; msg += "\n";
    }
    msg += "data: ";  msg += data;  msg += "\n\n";
    state = SEND_BODY;
    return write(msg);
}