### PR TITLE
增加 mqtt_client_set_host  接口函数, 

### DIFF
--- a/mqtt/mqtt_client.c
+++ b/mqtt/mqtt_client.c
@@ -485,6 +485,12 @@ void mqtt_client_set_connect_timeout(mqtt_client_t* cli, int ms) {
     cli->connect_timeout = ms;
 }
 
+void mqtt_client_set_host(mqtt_client_t* cli, const char* host, int port, int ssl) {
+    hv_strncpy(cli->host, host, sizeof(cli->host));
+    cli->port = port;
+    cli->ssl = ssl;
+}
+
 int mqtt_client_connect(mqtt_client_t* cli, const char* host, int port, int ssl) {
     if (!cli) return -1;
     hv_strncpy(cli->host, host, sizeof(cli->host));

--- a/mqtt/mqtt_client.h
+++ b/mqtt/mqtt_client.h
@@ -102,6 +102,7 @@ HV_EXPORT int mqtt_client_reconnect(mqtt_client_t* cli);
 // on_connect -> mqtt_client_login ->
 // on_connack
 HV_EXPORT void mqtt_client_set_connect_timeout(mqtt_client_t* cli, int ms);
+HV_EXPORT void mqtt_client_set_host(mqtt_client_t* cli, const char* host, int port, int ssl);
 HV_EXPORT int  mqtt_client_connect(mqtt_client_t* cli,
         const char* host,
         int port DEFAULT(DEFAULT_MQTT_PORT),
@@ -201,6 +202,10 @@ public:
 
     void setConnectTimeout(int ms) {
         mqtt_client_set_connect_timeout(client, ms);
+    }
+
+    void setHost(const char* host, int port = DEFAULT_MQTT_PORT, int ssl = 0) {
+        mqtt_client_set_host(client, host, port, ssl);
     }
 
     int connect(const char* host, int port = DEFAULT_MQTT_PORT, int ssl = 0) {


### PR DESCRIPTION
add mqtt_client_set_host function, used by switch host when connected…

添加 mqtt_client_set_host  接口函数, 用于当连接断开的时候切换服务器. 