### PR TITLE
fix:使用evpp=off编译后  在cpp文件中找不到头文件的问题

### DIFF
--- a/hconfig.h.in
+++ b/hconfig.h.in
@@ -99,4 +99,6 @@
 #cmakedefine WITH_WEPOLL    1
 #cmakedefine WITH_KCP       1
 
+#cmakedefine WITH_EVPP      1
+
 #endif // HV_CONFIG_H_

--- a/hv.h
+++ b/hv.h
@@ -29,7 +29,7 @@
 #include "hbuf.h"
 
 // cpp
-#ifdef __cplusplus
+#if defined (__cplusplus) && defined (WITH_EVPP)
 #include "hmap.h"       // <map>
 #include "hstring.h"    // <string>
 #include "hfile.h"


### PR DESCRIPTION
使用cmake编译hv库时 如果使用with_evpp=off那么不会复制 hmap.h hstring.h等头文件
但是如果把hv.h加入到自己的cpp代码中 就会因为找不到hmap.h hstring.h等文件编译错误