### PR TITLE
改进 CMake 中 clock_gettime 的兼容性检查

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,14 @@ check_function("socketpair" "sys/socket.h")
 check_function("eventfd" "sys/eventfd.h")
 check_function("setproctitle" "unistd.h")
 
+if (NOT HAVE_CLOCK_GETTIME)
+    include(CheckLibraryExists)
+    check_library_exists(rt clock_gettime "" HAVE_CLOCK_GETTIME_IN_RT)
+    if (HAVE_CLOCK_GETTIME_IN_RT)
+        set(HAVE_CLOCK_GETTIME ${HAVE_CLOCK_GETTIME_IN_RT})
+    endif()
+endif()
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hconfig.h.in ${CMAKE_CURRENT_SOURCE_DIR}/hconfig.h)
 
 # see Makefile.in


### PR DESCRIPTION
## 改进 CMake 中 clock_gettime 的兼容性检查

### 方案一：最小化改动

在 `CMakeLists.txt` 中增加以下内容

```cmake
if (NOT HAVE_CLOCK_GETTIME)
    include(CheckLibraryExists)
    check_library_exists(rt clock_gettime "" HAVE_CLOCK_GETTIME_IN_RT)
    if (HAVE_CLOCK_GETTIME_IN_RT)
        set(HAVE_CLOCK_GETTIME ${HAVE_CLOCK_GETTIME_IN_RT})
    endif()
endif()
```

### 方案二：模块化改进

1. **新增宏定义**：
   在 `cmake/utils.cmake` 中新增宏 `project_check_library_function`，用于检查特定库中的函数是否存在。该宏的定义如下：

   ```cmake
   macro(project_check_library_function library function local)
       string(TOUPPER ${library} str1)
       string(TOUPPER ${function} str2)
       set(str3 HAVE_${str2}_IN_${str1})
       check_library_exists("${library}" "${function}" "${local}" ${str3})
       if (${str3})
           set(${str3} 1)
       else()
           set(${str3} 0)
       endif()
   endmacro()
   ```

2. **更新 `CMakeLists.txt`**：
   在 `CMakeLists.txt` 中使用新定义的宏来检查 `clock_gettime` 函数是否存在于 `rt` 库中：

   ```cmake
   project_check_library_function("rt" "clock_gettime" "")
   ```

3. **更新 `hconfig.h.in`**：
   修改 `hconfig.h.in` 文件，以支持新的检查结果：

   ```c
   #ifndef HAVE_CLOCK_GETTIME
   #define HAVE_CLOCK_GETTIME (@HAVE_CLOCK_GETTIME@ | @HAVE_CLOCK_GETTIME_IN_RT@)
   #endif
   ```

方案二更加遵循原cmake脚本的风格, 而当前提交的代码采用的是改动更小的方案一。

