### PR TITLE
Update base64.h

### DIFF
--- a/util/base64.h
+++ b/util/base64.h
@@ -4,7 +4,7 @@
 #include "hexport.h"
 
 #define BASE64_ENCODE_OUT_SIZE(s)   (((s) + 2) / 3 * 4)
-#define BASE64_DECODE_OUT_SIZE(s)   (((s)) / 4 * 3)
+#define BASE64_DECODE_OUT_SIZE(s)   (((s) + 3) / 4 * 3)
 
 BEGIN_EXTERN_C
 


### PR DESCRIPTION
修复当输入in是不完整base64编码时，且长度不是4的倍数，会导致解码输出数据多一个字节，超出out缓冲区，出现内存溢出的行为。