### PR TITLE
List directory content using static routing

### DIFF
--- a/examples/http_server_test.cpp
+++ b/examples/http_server_test.cpp
@@ -39,6 +39,8 @@ int main(int argc, char** argv) {
     /* Static file service */
     // curl -v http://ip:port/
     router.Static("/", "./html");
+    // curl -v http://ip:port/docs/
+    router.Static("/docs/", "./docs");
 
     /* Forward proxy service */
     router.EnableForwardProxy();


### PR DESCRIPTION
支持如果路由的静态路径下没有index.html文件的情况下，应答为当前文件夹下的文件列表，现实场景中适合路由日志路径，方便取出日志