### PR TITLE
fix: improve compiler compatibility and warnings

### DIFF
--- a/base/hatomic.h
+++ b/base/hatomic.h
@@ -57,7 +57,7 @@ static inline bool atomic_flag_test_and_set(atomic_flag* p) {
 #define ATOMIC_INC          InterlockedIncrement
 #define ATOMIC_DEC          InterlockedDecrement
 
-#elif defined(__GNUC__)
+#elif __GNUC_PREREQ(4, 1)
 
 #define ATOMIC_FLAG_TEST_AND_SET    atomic_flag_test_and_set
 static inline bool atomic_flag_test_and_set(atomic_flag* p) {

--- a/base/hplatform.h
+++ b/base/hplatform.h
@@ -141,6 +141,10 @@
 #warning "Untested compiler!"
 #endif
 
+#ifndef __GNUC_PREREQ
+#define __GNUC_PREREQ(a, b)	0
+#endif
+
 // headers
 #ifdef OS_WIN
     #ifndef _WIN32_WINNT

--- a/base/htime.c
+++ b/base/htime.c
@@ -15,11 +15,11 @@ unsigned int gettick_ms() {
 #elif HAVE_CLOCK_GETTIME
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+    return (unsigned int)ts.tv_sec * 1000 + (unsigned int)ts.tv_nsec / 1000000;
 #else
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+    return (unsigned int)tv.tv_sec * 1000 + (unsigned int)tv.tv_usec / 1000;
 #endif
 }
 

--- a/event/hloop.c
+++ b/event/hloop.c
@@ -187,8 +187,10 @@ process_timers:
     //         blocktime, nios, loop->nios, ntimers, loop->ntimers, nidles, loop->nidles,
     //         loop->nactives, npendings, ncbs);
     return ncbs;
+    (void)nios;
 }
 
+#ifdef DEBUG
 static void hloop_stat_timer_cb(htimer_t* timer) {
     hloop_t* loop = timer->loop;
     // hlog_set_level(LOG_LEVEL_DEBUG);
@@ -198,6 +200,7 @@ static void hloop_stat_timer_cb(htimer_t* timer) {
         (unsigned long long)loop->loop_cnt,
         loop->nactives, loop->nios, loop->ntimers, loop->nidles);
 }
+#endif
 
 static void eventfd_read_cb(hio_t* io, void* buf, int readbytes) {
     hloop_t* loop = io->loop;

--- a/ssl/wintls.c
+++ b/ssl/wintls.c
@@ -85,7 +85,7 @@ const char* hssl_backend()
     return "schannel";
 }
 
-static PCCERT_CONTEXT getservercert(const char* path)
+static inline PCCERT_CONTEXT getservercert(const char* path)
 {
     /*
     According to the information I searched from the internet, it is not possible to specify an x509 private key and certificate using the


### PR DESCRIPTION
### 变更内容
- 添加 `__GNUC_PREREQ` 检查以支持原子操作（需要 GCC 4.1+）
- 在 `gettick_ms()` 中添加显式类型转换以修复整数溢出风险
- 消除未使用变量/函数的编译警告

---

### Changes
- Add `__GNUC_PREREQ` check for atomic operations (requires GCC 4.1+)
- Fix integer overflow risk in `gettick_ms()` with explicit type casting
- Eliminate unused variable/function warnings
