### PR TITLE
解决Mac编译错误，消除riscv编译警告

### DIFF
--- a/base/hplatform.h
+++ b/base/hplatform.h
@@ -60,6 +60,8 @@
     #define ARCH_MIPS64
 #elif defined(__mips__)
     #define ARCH_MIPS
+#elif defined(__riscv)
+    #define ARCH_RISCV
 #else
     #warning "Untested hardware architecture!"
 #endif

--- a/event/hloop.c
+++ b/event/hloop.c
@@ -10,6 +10,10 @@
 #include "hsocket.h"
 #include "hthread.h"
 
+#if defined(__APPLE__)
+#undef HAVE_EVENTFD
+#endif
+
 #if defined(OS_UNIX) && HAVE_EVENTFD
 #include "sys/eventfd.h"
 #endif

--- a/event/hloop.c
+++ b/event/hloop.c
@@ -10,10 +10,6 @@
 #include "hsocket.h"
 #include "hthread.h"
 
-#if defined(__APPLE__)
-#undef HAVE_EVENTFD
-#endif
-
 #if defined(OS_UNIX) && HAVE_EVENTFD
 #include "sys/eventfd.h"
 #endif


### PR DESCRIPTION
1. 解决直接make时MacOs系统编译错误
2. 消除riscv架构处理器编译警告