### PR TITLE
build: update CMake policy to improve compatibility with modern CMake…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
+cmake_policy(SET CMP0077 NEW)
 
 project(hv VERSION 1.3.3)
 


### PR DESCRIPTION

## 问题描述

当 libhv 作为 CMake 子模块被引用时，我们可以通过预设变量来控制构建选项：

```cmake
set(BUILD_SHARED ON CACHE BOOL "build shared library")
set(BUILD_STATIC OFF CACHE BOOL "build static library")
set(WITH_EVPP ON CACHE BOOL "compile evpp")
set(WITH_HTTP ON CACHE BOOL "compile http")
set(WITH_HTTP_SERVER ON CACHE BOOL "compile http/server")
set(WITH_HTTP_CLIENT ON CACHE BOOL "compile http/client")

add_subdirectory(libhv)
include_directories(libhv/include)
add_library(hv::hv ALIAS hv)
```

而在 CMake 3.13+ 版本中，支持更简洁的方式：

```cmake
set(BUILD_SHARED ON)
set(BUILD_STATIC OFF)
set(WITH_EVPP ON)
set(WITH_HTTP ON)
set(WITH_HTTP_SERVER ON)
set(WITH_HTTP_CLIENT ON)

add_subdirectory(libhv)
include_directories(libhv/include)
add_library(hv::hv ALIAS hv)
```

也就是改用普通变量，但当前使用这种方式导入 libhv 会触发以下 CMake 警告：

```
CMake Warning (dev): Policy CMP0077 is not set: option() honors normal variables.
Run "cmake --help-policy CMP0077" for policy details.
For compatibility with older versions of CMake, option is clearing the normal variable 'BUILD_SHARED'.
```

由于未设置 CMP0077 策略，CMake 会清除普通变量以保持向后兼容性。

## 解决方案

在 CMakeLists.txt 开头添加以下策略设置：

```cmake
cmake_policy(SET CMP0077 NEW)
```

此修改使 `option()` 命令优先使用父项目中预设的变量值，符合现代 CMake 最佳实践。
同时，不影响现有构建行为, 保持最低 CMake 3.6 版本要求。

## 参考

- [CMake CMP0077 官方文档](https://cmake.org/cmake/help/latest/policy/CMP0077.html)
- [Stack Overflow: How to force cmake to use the new version of CMP0077](https://stackoverflow.com/questions/66340703/how-to-force-cmake-to-use-the-new-version-of-cmp0077-allow-options-to-be-set-fr)
