### PR TITLE
fix FileCache map key name dos attack

### DIFF
--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -524,6 +524,7 @@ int HttpHandler::defaultRequestHandler() {
 int HttpHandler::defaultStaticHandler() {
     // file service
     std::string path = req->Path();
+    while(path.back() == '\\') path.pop_back();
     const char* req_path = path.c_str();
     // path safe check
     if (req_path[0] != '/' || strstr(req_path, "/..") || strstr(req_path, "\\..")) {


### PR DESCRIPTION
解决相同文件名MAP缓存理论上仅存在一个，但URL可通过末尾追加任意数量字符 \\\\ 产生很多个相同文件MAP不同键名的缓存形成攻击