### PR TITLE
Minor fixes for legacy macOS

### DIFF
--- a/base/hplatform.h
+++ b/base/hplatform.h
@@ -17,6 +17,7 @@
 #elif defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
     #include <TargetConditionals.h>
     #if defined(TARGET_OS_MAC) && TARGET_OS_MAC
+        #include <AvailabilityMacros.h>
         #define OS_MAC
     #elif defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
         #define OS_IOS

--- a/base/hplatform.h
+++ b/base/hplatform.h
@@ -63,6 +63,10 @@
     #define ARCH_MIPS
 #elif defined(__riscv)
     #define ARCH_RISCV
+#elif defined(__ppc64__) || defined(__powerpc64__)
+    #define ARCH_PPC64
+#elif defined(__ppc__) || defined(__powerpc__)
+    #define ARCH_PPC
 #else
     #warning "Untested hardware architecture!"
 #endif
@@ -260,7 +264,8 @@
       defined(__MIPSEL)  || defined(__MIPS64EL)
     #define BYTE_ORDER  LITTLE_ENDIAN
 #elif defined(__ARMEB__) || defined(__AARCH64EB__) || \
-      defined(__MIPSEB)  || defined(__MIPS64EB)
+      defined(__MIPSEB)  || defined(__MIPS64EB) || \
+      defined(__ppc__)   || defined(__ppc64__)
     #define BYTE_ORDER  BIG_ENDIAN
 #elif defined(OS_WIN)
     #define BYTE_ORDER  LITTLE_ENDIAN

--- a/base/hthread.h
+++ b/base/hthread.h
@@ -19,7 +19,12 @@
 #elif defined(OS_DARWIN)
 static inline long hv_gettid() {
     uint64_t tid = 0;
+/* pthread_threadid_np is not available before 10.6 and in 10.6 for ppc */
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || defined(__POWERPC__)
+    tid = pthread_mach_thread_np(pthread_self());
+#else
     pthread_threadid_np(NULL, &tid);
+#endif
     return tid;
 }
 #elif HAVE_PTHREAD_H


### PR DESCRIPTION
1. `pthread_threadid_np` does not exist before 10.6 and is disabled on 10.6 for powerpc. Provide a fallback.
2. Add basic powerpc macros. (`__ppc64__` and `__ppc__` are Apple-specific, so we know those can only be Big-endian.)