### PR TITLE
修复HTTP服务Windows性能异常和中文路径相关Bug

### DIFF
--- a/cpputil/hstring.cpp
+++ b/cpputil/hstring.cpp
@@ -225,4 +225,25 @@ std::string NetAddr::to_string(const char* ip, int port) {
     return hv::asprintf(fmt, ip, port);
 }
 
+#ifdef OS_WIN
+std::string wchar_to_utf8(const std::wstring &wstr) {
+  std::string str(4 * wstr.size() + 1, '\0');
+  str.resize(WideCharToMultiByte(
+    CP_UTF8, 0, 
+    wstr.c_str(), wstr.size(), 
+    const_cast<char*>(str.data()), str.size(), 
+    NULL, NULL));
+  return str;
+}
+
+std::wstring utf8_to_wchar(const std::string &str) {
+  std::wstring wstr(2 * str.size() + 1, '\0');
+  wstr.resize(MultiByteToWideChar(
+    CP_UTF8, 0, 
+    str.c_str(), str.size(), 
+    const_cast<wchar_t*>(wstr.data()), wstr.size()));
+  return wstr;
+}
+#endif // OS_WIN
+
 } // end namespace hv

--- a/cpputil/hstring.h
+++ b/cpputil/hstring.h
@@ -88,6 +88,12 @@ struct HV_EXPORT NetAddr {
     static std::string to_string(const char* ip, int port);
 };
 
+// windows wchar and utf8 conver
+#ifdef OS_WIN
+HV_EXPORT std::string wchar_to_utf8(const std::wstring &wstr);
+HV_EXPORT std::wstring utf8_to_wchar(const std::string &str);
+#endif // OS_WIN
+
 } // end namespace hv
 
 #endif // HV_STRING_H_

--- a/http/server/FileCache.cpp
+++ b/http/server/FileCache.cpp
@@ -8,8 +8,8 @@
 #include "httpdef.h"    // import http_content_type_str_by_suffix
 #include "http_page.h"  // import make_index_of_page
 
-#ifdef _MSC_VER
-#include <codecvt>
+#ifdef OS_WIN
+#include "hstring.h" // import hv::utf8_to_wchar
 #endif
 
 #define ETAG_FMT    "\"%zx-%zx\""
@@ -19,27 +19,26 @@ FileCache::FileCache() {
     expired_time  = 60; // s
 }
 
-static int hv_open(char const* filepath, int flags) {
-#ifdef _MSC_VER
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> conv;
-    auto wfilepath = conv.from_bytes(filepath);
-    int fd = _wopen(wfilepath.c_str(), flags);
-#else
-    int fd = open(filepath, flags);
-#endif
-    return fd;
-}
-
 file_cache_ptr FileCache::Open(const char* filepath, OpenParam* param) {
     std::lock_guard<std::mutex> locker(mutex_);
     file_cache_ptr fc = Get(filepath);
+#ifdef OS_WIN
+    std::wstring wfilepath;
+#endif
     bool modified = false;
     if (fc) {
         time_t now = time(NULL);
         if (now - fc->stat_time > stat_interval) {
-            modified = fc->is_modified();
             fc->stat_time = now;
             fc->stat_cnt++;
+#ifdef OS_WIN
+            wfilepath = hv::utf8_to_wchar(filepath);
+            now = fc->st.st_mtime;
+            _wstat(wfilepath.c_str(), (struct _stat*)&fc->st);
+            modified = now != fc->st.st_mtime;
+#else
+            modified = fc->is_modified();
+#endif
         }
         if (param->need_read) {
             if (!modified && fc->is_complete()) {
@@ -48,31 +47,32 @@ file_cache_ptr FileCache::Open(const char* filepath, OpenParam* param) {
         }
     }
     if (fc == NULL || modified || param->need_read) {
+        struct stat st;
         int flags = O_RDONLY;
 #ifdef O_BINARY
         flags |= O_BINARY;
 #endif
-        int fd = hv_open(filepath, flags);
-        if (fd < 0) {
 #ifdef OS_WIN
+        if(wfilepath.empty()) wfilepath = hv::utf8_to_wchar(filepath);
+        const int fd = _wopen(wfilepath.c_str(), flags);
+        if (fd < 0) {
             // NOTE: open(dir) return -1 on windows
-            if (!hv_isdir(filepath)) {
+            _wstat(wfilepath.c_str(), (struct _stat*)&st);
+            if(!S_ISDIR(st.st_mode)) {
                 param->error = ERR_OPEN_FILE;
                 return NULL;
             }
+        }
 #else
+        const int fd = open(filepath, flags);
+        if (fd < 0) {
             param->error = ERR_OPEN_FILE;
             return NULL;
-#endif
         }
+#endif
         defer(if (fd > 0) { close(fd); })
         if (fc == NULL) {
-            struct stat st;
-            if (fd > 0) {
-                fstat(fd, &st);
-            } else {
-                stat(filepath, &st);
-            }
+            if (fd > 0) fstat(fd, &st);
             if (S_ISREG(st.st_mode) ||
                 (S_ISDIR(st.st_mode) &&
                  filepath[strlen(filepath)-1] == '/')) {


### PR DESCRIPTION
Windows HTTP服务注意了 #559 合并之后的版本性能是有异常的，我也是最近压测无意中发现，分析源码排查老半天才发现原因在codecvt编码转换

修复Windows defaultStaticHandler性能错误
Windows版本从合并 #559 之后HTTP服务默认静态处理因编码转换严重影响服务性能。
为了方便解决Windows高性能宽字符函数编码转换，在hstring.h增加了hv::wchar_to_utf8和hv::utf8_to_wchar函数
顺便修复http服务遇到中文路径时stat不可用导致文件缓存逻辑故障 和 http服务目录索引中文乱码问题

![6693a712a6bbd5a9d8adcffc6f99c178](https://github.com/user-attachments/assets/184a5b0f-36e8-413d-add9-a4291b063e6c)
