### PR TITLE
增强优化修复一些主要对HttpServer业务的使用

### DIFF
--- a/cpputil/hstring.cpp
+++ b/cpputil/hstring.cpp
@@ -226,24 +226,25 @@ std::string NetAddr::to_string(const char* ip, int port) {
 }
 
 #ifdef OS_WIN
-std::string wchar_to_utf8(const std::wstring &wstr) {
+std::string wchar_to_string(const UINT codePage, const std::wstring &wstr) {
   std::string str(4 * wstr.size() + 1, '\0');
   str.resize(WideCharToMultiByte(
-    CP_UTF8, 0, 
-    wstr.c_str(), wstr.size(), 
-    const_cast<char*>(str.data()), str.size(), 
+    codePage, 0,
+    wstr.c_str(), wstr.size(),
+    const_cast<char*>(str.data()), str.size(),
     NULL, NULL));
   return str;
 }
 
-std::wstring utf8_to_wchar(const std::string &str) {
-  std::wstring wstr(2 * str.size() + 1, '\0');
+std::wstring string_to_wchar(const UINT codePage, const std::string &str) {
+  std::wstring wstr(2 * str.size() + 2, '\0');
   wstr.resize(MultiByteToWideChar(
-    CP_UTF8, 0, 
-    str.c_str(), str.size(), 
+    codePage, 0,
+    str.c_str(), str.size(),
     const_cast<wchar_t*>(wstr.data()), wstr.size()));
   return wstr;
 }
+
 #endif // OS_WIN
 
 } // end namespace hv

--- a/cpputil/hstring.h
+++ b/cpputil/hstring.h
@@ -88,10 +88,31 @@ struct HV_EXPORT NetAddr {
     static std::string to_string(const char* ip, int port);
 };
 
-// windows wchar and utf8 conver
+// windows wchar and utf8/ansi conver
 #ifdef OS_WIN
-HV_EXPORT std::string wchar_to_utf8(const std::wstring &wstr);
-HV_EXPORT std::wstring utf8_to_wchar(const std::string &str);
+HV_EXPORT std::string wchar_to_string(const UINT codePage, const std::wstring &wstr);
+HV_EXPORT std::wstring string_to_wchar(const UINT codePage, const std::string &str);
+
+HV_INLINE std::string wchar_to_utf8(const std::wstring &wstr) {
+    return wchar_to_string(CP_UTF8, wstr);
+}
+
+HV_INLINE std::string wchar_to_ansi(const std::wstring &wstr) {
+    return wchar_to_string(CP_ACP, wstr);
+}
+
+HV_INLINE std::wstring utf8_to_wchar(const std::string &str) {
+    return string_to_wchar(CP_UTF8, str);
+}
+
+HV_INLINE std::string utf8_to_ansi(const std::string &str) {
+    return wchar_to_string(CP_ACP, string_to_wchar(CP_UTF8, str));
+}
+
+HV_INLINE std::string ansi_to_utf8(const std::string &str) {
+    return wchar_to_string(CP_UTF8, string_to_wchar(CP_ACP, str));
+}
+
 #endif // OS_WIN
 
 } // end namespace hv

--- a/cpputil/hurl.cpp
+++ b/cpputil/hurl.cpp
@@ -203,4 +203,45 @@ std::string escapeHTML(const std::string& str)  {
     return ostr;
 }
 
+std::string compressRelativePath(const std::string &path) {
+    std::string result;
+    result.reserve(path.size());
+    const char *p = path.c_str();
+    while (*p != '\0') {
+        if (*p == '/') {
+            if (result.back() != '/') result.push_back('/');
+            ++p;
+            continue;
+        }
+        if (*p == '.' && result.back() == '/') {
+            if (p[1] == '\0') break;
+            if (p[1] == '/') {
+                p += 2;
+                continue;
+            }
+        }
+#ifdef OS_WIN
+        if (*p == '\\') {
+            if (result.back() != '/') result.push_back('/');
+            ++p;
+            continue;
+        }
+        if (*p == '.') {
+            if ((p[1] == '\\' || p[1] == '/') && result.back() == '/') {
+                p += 2;
+                continue;
+            }
+            // windows supports trailing infinite '.'
+            int i = 1;
+            while (*(++p) == '.') { ++i; }
+            if (*p == '\0') break;
+            result.append(i, '.');
+        }
+#endif
+        result.push_back(*p);
+        ++p;
+    }
+    return result;
+}
+
 }

--- a/cpputil/hurl.h
+++ b/cpputil/hurl.h
@@ -36,6 +36,8 @@ HV_INLINE std::string escapeURL(const std::string& url) {
 
 HV_EXPORT std::string escapeHTML(const std::string& str);
 
+HV_EXPORT std::string compressRelativePath(const std::string &path);
+
 } // end namespace hv
 
 #endif // HV_URL_H_

--- a/docs/cn/HttpServer.md
+++ b/docs/cn/HttpServer.md
@@ -93,10 +93,11 @@ class HttpService {
     // 返回注册的路由路径列表
     hv::StringList Paths();
 
-    // 处理流程：前处理器 -> 中间件 -> 处理器 -> 后处理器
-    // preprocessor -> middleware -> processor -> postprocessor
+    // 处理流程：标头处理器 -> 前处理器 -> 中间件 -> 处理器 -> 后处理器
+    // headerHandler -> preprocessor -> middleware -> processor -> postprocessor
 
     // 数据成员
+    http_handler    headerHandler;  // 标头处理器
     http_handler    preprocessor;   // 前处理器
     http_handlers   middleware;     // 中间件
     http_handler    processor;      // 处理器

--- a/event/hevent.c
+++ b/event/hevent.c
@@ -602,7 +602,7 @@ static void __write_timeout_cb(htimer_t* timer) {
         if (io->io_type & HIO_TYPE_SOCKET) {
             char localaddrstr[SOCKADDR_STRLEN] = {0};
             char peeraddrstr[SOCKADDR_STRLEN] = {0};
-            hlogw("write timeout [%s] <=> [%s]",
+            hlogi("write timeout [%s] <=> [%s]",
                     SOCKADDR_STR(io->localaddr, localaddrstr),
                     SOCKADDR_STR(io->peeraddr, peeraddrstr));
         }

--- a/event/nio.c
+++ b/event/nio.c
@@ -80,7 +80,7 @@ static void ssl_server_handshake(hio_t* io) {
         }
     }
     else {
-        hloge("ssl handshake failed: %d", ret);
+        hloge("ssl server handshake failed: %d", ret);
         io->error = ERR_SSL_HANDSHAKE;
         hio_close(io);
     }
@@ -101,7 +101,7 @@ static void ssl_client_handshake(hio_t* io) {
         }
     }
     else {
-        hloge("ssl handshake failed: %d", ret);
+        hloge("ssl client handshake failed: %d", ret);
         io->error = ERR_SSL_HANDSHAKE;
         hio_close(io);
     }

--- a/examples/httpd/handler.cpp
+++ b/examples/httpd/handler.cpp
@@ -9,10 +9,8 @@
 #include "hstring.h"
 #include "EventLoop.h" // import setTimeout, setInterval
 
-int Handler::preprocessor(HttpRequest* req, HttpResponse* resp) {
+int Handler::headerHandler(HttpRequest* req, HttpResponse* resp) {
     // printf("%s:%d\n", req->client_addr.ip.c_str(), req->client_addr.port);
-    // printf("%s\n", req->Dump(true, true).c_str());
-
 #if REDIRECT_HTTP_TO_HTTPS
     // 301
     if (req->scheme == "http") {
@@ -25,6 +23,11 @@ int Handler::preprocessor(HttpRequest* req, HttpResponse* resp) {
     // if (req->content_type != APPLICATION_JSON) {
     //     return response_status(resp, HTTP_STATUS_BAD_REQUEST);
     // }
+    return HTTP_STATUS_NEXT;
+}
+
+int Handler::preprocessor(HttpRequest* req, HttpResponse* resp) {
+    // printf("%s\n", req->Dump(true, true).c_str());
 
     // Deserialize request body to json, form, etc.
     req->ParseBody();

--- a/examples/httpd/handler.h
+++ b/examples/httpd/handler.h
@@ -5,7 +5,8 @@
 
 class Handler {
 public:
-    // preprocessor => middleware -> handlers => postprocessor
+    // headerHandler => preprocessor => middleware -> handlers => postprocessor
+    static int headerHandler(HttpRequest* req, HttpResponse* resp);
     static int preprocessor(HttpRequest* req, HttpResponse* resp);
     static int postprocessor(HttpRequest* req, HttpResponse* resp);
     static int errorHandler(const HttpContextPtr& ctx);

--- a/examples/httpd/router.cpp
+++ b/examples/httpd/router.cpp
@@ -7,8 +7,9 @@
 
 void Router::Register(hv::HttpService& router) {
     /* handler chain */
-    // preprocessor -> middleware -> processor -> postprocessor
+    // headerHandler -> preprocessor -> middleware -> processor -> postprocessor
     // processor: pathHandlers -> staticHandler -> errorHandler
+    router.headerHandler = Handler::headerHandler;
     router.preprocessor = Handler::preprocessor;
     router.postprocessor = Handler::postprocessor;
     // router.errorHandler = Handler::errorHandler;

--- a/http/HttpMessage.h
+++ b/http/HttpMessage.h
@@ -386,6 +386,13 @@ public:
     unsigned            redirect: 1;
     unsigned            proxy   : 1;
     unsigned            cancel  : 1;
+    struct {
+        unsigned        relative_current : 1;    // ref regxp:(/|\\)\.(/|\\|$)
+        unsigned        relative_parent  : 1;    // ref regxp:(/|\\)\.\.(/|\\|$)
+        unsigned        crlf             : 1;    // fix CVE-2023-26147
+        unsigned        repeat_slash     : 1;    // repeat "\\" or "//"
+        unsigned        back_slash       : 1;    // note '\' compatibility
+    } path_safe;
 
     HttpRequest();
 
@@ -420,6 +427,8 @@ public:
     // url -> structed url
     void ParseUrl();
 
+    // path safe check
+    void CheckPathSafe();
     // /path?query#fragment
     std::string FullPath() { return path; }
     // /path

--- a/http/HttpParser.cpp
+++ b/http/HttpParser.cpp
@@ -2,6 +2,7 @@
 
 #include "Http1Parser.h"
 #include "Http2Parser.h"
+#include "hlog.h"
 
 HttpParser* HttpParser::New(http_session_type type, http_version version) {
     HttpParser* hp = NULL;
@@ -12,7 +13,7 @@ HttpParser* HttpParser::New(http_session_type type, http_version version) {
 #ifdef WITH_NGHTTP2
         hp = new Http2Parser(type);
 #else
-        fprintf(stderr, "Please recompile WITH_NGHTTP2!\n");
+        hlogi("Please recompile WITH_NGHTTP2!\n");
 #endif
     }
 

--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -42,6 +42,7 @@ HttpHandler::HttpHandler(hio_t* io) :
     tid(0),
     // for http
     io(io),
+    server(NULL),
     service(NULL),
     api_handler(NULL),
     // for websocket
@@ -251,13 +252,23 @@ int HttpHandler::invokeHttpHandler(const http_handler* handler) {
 
 void HttpHandler::onHeadersComplete() {
     // printf("onHeadersComplete\n");
-    int status_code = handleRequestHeaders();
-    if (status_code != HTTP_STATUS_OK) {
-        error = ERR_REQUEST;
-        return;
+    handleRequestHeaders();
+    if (service->headerHandler) {
+        const int status_code = customHttpHandler(service->headerHandler);
+        if (status_code != HTTP_STATUS_OK && status_code != HTTP_STATUS_NEXT) {
+            SetError(ERR_REQUEST, static_cast<http_status>(status_code));
+            return;
+        }
     }
 
     HttpRequest* pReq = req.get();
+    if (req->path_safe.crlf) {
+        // fix CVE-2023-26147
+        hloge("[%s:%d] Illegal crlf path: %s", ip, port, pReq->path.c_str());
+        SetError(ERR_REQUEST);
+        return;
+    }
+
     if (service && service->pathHandlers.size() != 0) {
         service->GetRoute(pReq, &api_handler);
     }
@@ -331,7 +342,7 @@ void HttpHandler::onMessageComplete() {
 
     if (status_code != HTTP_STATUS_NEXT) {
         // keepalive ? Reset : Close
-        if (keepalive) {
+        if (error == 0 && keepalive) {
             Reset();
         } else {
             state = WANT_CLOSE;
@@ -339,7 +350,7 @@ void HttpHandler::onMessageComplete() {
     }
 }
 
-int HttpHandler::handleRequestHeaders() {
+void HttpHandler::handleRequestHeaders() {
     HttpRequest* pReq = req.get();
     pReq->scheme = ssl ? "https" : "http";
     pReq->client_addr.ip = ip;
@@ -367,16 +378,7 @@ int HttpHandler::handleRequestHeaders() {
 
     // printf("url=%s\n", pReq->url.c_str());
     pReq->ParseUrl();
-    // printf("path=%s\n",  pReq->path.c_str());
-    // fix CVE-2023-26147
-    if (pReq->path.find("%") != std::string::npos) {
-        std::string unescaped_path = HUrl::unescape(pReq->path);
-        if (unescaped_path.find("\r\n") != std::string::npos) {
-            hlogw("Illegal path: %s\n",  unescaped_path.c_str());
-            resp->status_code = HTTP_STATUS_BAD_REQUEST;
-            return resp->status_code;
-        }
-    }
+    pReq->CheckPathSafe();
 
     if (proxy) {
         // Proxy-Connection
@@ -404,7 +406,6 @@ int HttpHandler::handleRequestHeaders() {
     }
 
     // TODO: rewrite url
-    return HTTP_STATUS_OK;
 }
 
 void HttpHandler::handleExpect100() {
@@ -467,9 +468,9 @@ postprocessor:
         pResp->status_code = (http_status)status_code;
         if (pResp->status_code >= 400 && pResp->body.size() == 0 && pReq->method != HTTP_HEAD) {
             if (service->errorHandler) {
-                customHttpHandler(service->errorHandler);
+                status_code = customHttpHandler(service->errorHandler);
             } else {
-                defaultErrorHandler();
+                status_code = defaultErrorHandler();
             }
         }
     }
@@ -481,7 +482,10 @@ postprocessor:
         pResp->headers["Etag"] = fc->etag;
     }
     if (service->postprocessor) {
-        customHttpHandler(service->postprocessor);
+        status_code = customHttpHandler(service->postprocessor);
+    }
+    if (status_code == HTTP_STATUS_WANT_CLOSE) {
+        error = ERR_REQUEST;
     }
 
     if (writer && writer->state != hv::HttpResponseWriter::SEND_BEGIN) {
@@ -525,13 +529,20 @@ int HttpHandler::defaultStaticHandler() {
     // file service
     std::string path = req->Path();
     const char* req_path = path.c_str();
-    // path safe check
-    if (req_path[0] != '/' || strstr(req_path, "/..") || strstr(req_path, "\\..")) {
+    if (req->path_safe.relative_parent) {
+        hloge("[%s:%d] not allowed relative parent path: %s", ip, port, req_path);
         return HTTP_STATUS_BAD_REQUEST;
     }
 
     std::string filepath;
-    bool is_dir = path.back() == '/' &&
+    if (req->path_safe.relative_current || req->path_safe.repeat_slash || req->path_safe.back_slash) {
+        // prevent malicious request format '/./////\\ \file.txt\...' Duplicate alloc of the same file '/file.txt' cache map
+        path = hv::compressRelativePath(path);
+        req_path = path.c_str();
+        hlogi("unique map filepath after relative path compress: %s", req_path);
+    }
+
+    const bool is_dir = path.back() == '/' &&
                   service->index_of.size() > 0 &&
                   hv_strstartswith(req_path, service->index_of.c_str());
     if (is_dir) {
@@ -574,7 +585,7 @@ int HttpHandler::defaultStaticHandler() {
             if (service->largeFileHandler) {
                 status_code = customHttpHandler(service->largeFileHandler);
             } else {
-                status_code = defaultLargeFileHandler();
+                status_code = defaultLargeFileHandler(filepath);
             }
         }
         return status_code;
@@ -593,7 +604,7 @@ int HttpHandler::defaultStaticHandler() {
             if (service->largeFileHandler) {
                 status_code = customHttpHandler(service->largeFileHandler);
             } else {
-                status_code = defaultLargeFileHandler();
+                status_code = defaultLargeFileHandler(filepath);
             }
         } else {
             status_code = HTTP_STATUS_NOT_FOUND;
@@ -618,10 +629,9 @@ int HttpHandler::defaultStaticHandler() {
     return status_code;
 }
 
-int HttpHandler::defaultLargeFileHandler() {
+int HttpHandler::defaultLargeFileHandler(const std::string &filepath) {
     if (!writer) return HTTP_STATUS_NOT_IMPLEMENTED;
     if (!isFileOpened()) {
-        std::string filepath = service->GetStaticFilepath(req->Path().c_str());
         if (filepath.empty() || openFile(filepath.c_str()) != 0) {
             return HTTP_STATUS_NOT_FOUND;
         }
@@ -853,7 +863,7 @@ int HttpHandler::SendHttpStatusResponse(http_status status_code) {
     if (state > WANT_SEND) return 0;
     resp->status_code = status_code;
     addResponseHeaders();
-    HandleHttpRequest();
+    if (HandleHttpRequest() == HTTP_STATUS_NEXT) return 0;
     state = WANT_SEND;
     return SendHttpResponse();
 }
@@ -863,7 +873,11 @@ int HttpHandler::openFile(const char* filepath) {
     closeFile();
     file = new LargeFile;
     file->timer = INVALID_TIMER_ID;
+#ifdef OS_WIN
+    return file->open(hv::utf8_to_ansi(filepath).c_str(), "rb");
+#else
     return file->open(filepath, "rb");
+#endif
 }
 
 bool HttpHandler::isFileOpened() {
@@ -953,7 +967,7 @@ int HttpHandler::upgradeWebSocket() {
     if (iter_protocol != req->headers.end()) {
         hv::StringList subprotocols = hv::split(iter_protocol->second, ',');
         if (subprotocols.size() > 0) {
-            hlogw("%s: %s => just select first protocol %s", SEC_WEBSOCKET_PROTOCOL, iter_protocol->second.c_str(), subprotocols[0].c_str());
+            hlogw("[%s:%d] %s: %s => just select first protocol %s", ip, port, SEC_WEBSOCKET_PROTOCOL, iter_protocol->second.c_str(), subprotocols[0].c_str());
             resp->headers[SEC_WEBSOCKET_PROTOCOL] = subprotocols[0];
         }
     }
@@ -983,7 +997,7 @@ int HttpHandler::upgradeHTTP2() {
     SendHttpResponse();
 
     if (!SwitchHTTP2()) {
-        hloge("[%s:%d] unsupported HTTP2", ip, port);
+        hlogw("[%s:%d] unsupported HTTP2", ip, port);
         return SetError(ERR_INVALID_PROTOCOL);
     }
 
@@ -1010,7 +1024,7 @@ int HttpHandler::handleForwardProxy() {
     if (service && service->enable_forward_proxy) {
         return connectProxy(req->url);
     } else {
-        hlogw("Forbidden to forward proxy %s", req->url.c_str());
+        hlogw("[%s:%d] Forbidden to forward proxy %s", ip, port, req->url.c_str());
         SetError(HTTP_STATUS_FORBIDDEN, HTTP_STATUS_FORBIDDEN);
     }
     return 0;
@@ -1043,7 +1057,7 @@ int HttpHandler::connectProxy(const std::string& strUrl) {
     }
 
     if (forward_proxy && !service->IsTrustProxy(url.host.c_str())) {
-        hlogw("Forbidden to proxy %s", url.host.c_str());
+        hlogw("[%s:%d] Forbidden to proxy %s", ip, port, url.host.c_str());
         SetError(HTTP_STATUS_FORBIDDEN, HTTP_STATUS_FORBIDDEN);
         return 0;
     }

--- a/http/server/HttpHandler.h
+++ b/http/server/HttpHandler.h
@@ -51,6 +51,7 @@ public:
 
     // for http
     hio_t                   *io;
+    void                    *server;
     HttpService             *service;
     HttpRequestPtr          req;
     HttpResponsePtr         resp;
@@ -143,7 +144,7 @@ public:
 
 private:
     const HttpContextPtr& context();
-    int   handleRequestHeaders();
+    void  handleRequestHeaders();
     // Expect: 100-continue
     void  handleExpect100();
     void  addResponseHeaders();
@@ -156,7 +157,7 @@ private:
     // default handlers
     int defaultRequestHandler();
     int defaultStaticHandler();
-    int defaultLargeFileHandler();
+    int defaultLargeFileHandler(const std::string &filepath);
     int defaultErrorHandler();
     int customHttpHandler(const http_handler& handler);
     int invokeHttpHandler(const http_handler* handler);

--- a/http/server/HttpServer.cpp
+++ b/http/server/HttpServer.cpp
@@ -37,14 +37,17 @@ static void on_recv(hio_t* io, void* buf, int readbytes) {
 static void on_close(hio_t* io) {
     HttpHandler* handler = (HttpHandler*)hevent_userdata(io);
     if (handler == NULL) return;
-
-    hevent_set_userdata(io, NULL);
-    delete handler;
+    http_server_t* server = (http_server_t*)handler->server;
 
     EventLoop* loop = currentThreadEventLoop;
     if (loop) {
+        if (server->onClose) {
+            server->onClose(io);
+        }
         --loop->connectionNum;
     }
+    hevent_set_userdata(io, NULL);
+    delete handler;
 }
 
 static void on_accept(hio_t* io) {
@@ -65,8 +68,13 @@ static void on_accept(hio_t* io) {
         hio_close(io);
         return;
     }
+    if (server->onAccept) {
+        if (!server->onAccept(io)) {
+            hio_close(io);
+            return;
+        }
+    }
     ++loop->connectionNum;
-
     hio_setcb_close(io, on_close);
     hio_setcb_read(io, on_recv);
     hio_read(io);
@@ -82,6 +90,8 @@ static void on_accept(hio_t* io) {
     sockaddr_u* peeraddr = (sockaddr_u*)hio_peeraddr(io);
     sockaddr_ip(peeraddr, handler->ip, sizeof(handler->ip));
     handler->port = sockaddr_port(peeraddr);
+    // http server
+    handler->server = server;
     // http service
     handler->service = service;
     // websocket service

--- a/http/server/HttpServer.h
+++ b/http/server/HttpServer.h
@@ -29,6 +29,8 @@ typedef struct http_server_s {
     // hooks
     std::function<void()> onWorkerStart;
     std::function<void()> onWorkerStop;
+    std::function<bool(hio_t* io)> onAccept;
+    std::function<void(hio_t* io)> onClose;
     // SSL/TLS
     hssl_ctx_t  ssl_ctx;
     unsigned    alloced_ssl_ctx: 1;

--- a/http/server/HttpService.h
+++ b/http/server/HttpService.h
@@ -34,6 +34,7 @@
  */
 #define HTTP_STATUS_NEXT        0
 #define HTTP_STATUS_UNFINISHED  0
+#define HTTP_STATUS_WANT_CLOSE  1
 // NOTE: http_sync_handler run on IO thread
 typedef std::function<int(HttpRequest* req, HttpResponse* resp)>                            http_sync_handler;
 // NOTE: http_async_handler run on hv::async threadpool
@@ -108,7 +109,8 @@ namespace hv {
 
 struct HV_EXPORT HttpService {
     /* handler chain */
-    // preprocessor -> middleware -> processor -> postprocessor
+    // headerHandler -> preprocessor -> middleware -> processor -> postprocessor
+    http_handler        headerHandler;
     http_handler        preprocessor;
     http_handlers       middleware;
     // processor: pathHandlers -> staticHandler -> errorHandler

--- a/ssl/openssl.c
+++ b/ssl/openssl.c
@@ -1,5 +1,5 @@
 #include "hssl.h"
-
+#include "hlog.h"
 #ifdef WITH_OPENSSL
 
 #include "openssl/ssl.h"
@@ -117,6 +117,12 @@ int hssl_accept(hssl_t ssl) {
     else if (err == SSL_ERROR_WANT_WRITE) {
         return HSSL_WANT_WRITE;
     }
+    else if (err == SSL_ERROR_SYSCALL) {
+        hloge("SSL_accept errno:%d,error:%s", errno, strerror(errno));
+    }
+    else {
+        hloge("SSL_accept: %s", ERR_error_string(ERR_get_error(), NULL));
+    }
     return err;
 }
 
@@ -130,6 +136,12 @@ int hssl_connect(hssl_t ssl) {
     }
     else if (err == SSL_ERROR_WANT_WRITE) {
         return HSSL_WANT_WRITE;
+    }
+    else if (err == SSL_ERROR_SYSCALL) {
+        hloge("SSL_connect errno:%d,error:%s", errno, strerror(errno));
+    }
+    else {
+        hloge("SSL_connect: %s", ERR_error_string(ERR_get_error(), NULL));
     }
     return err;
 }


### PR DESCRIPTION
### 支持自定义 http 处理链 headerHandler
能够在内部一些默认处理之前最优先做业务处理，例如需要对请求头或Host域做检查，如果不合法可忽略hv内部的RecvBody，Expect100，Proxy，ProtocolUpgrade等等一系列的内置处理，也可提前做个性化的rewrite头部信息从而影响hv后续的一些默认处理行为。

### 支持 http 处理程序链返回 HTTP_STATUS_WANT_CLOSE
能够在各个处理链线程安全的通过返回此值要求无视Http头keep-alive强制关闭连接，甚至可选搭配处理链的回调中将ctx->writer->state = hv::HttpResponseWriter::SEND_END; 实现取消hv内部默认响应http状态包变为自定义响应非http报文或不响应任何数据，让非法访问无法探测外网端口的具体服务性质。

### 支持 http 服务器绑定 onAccept 和 onClose 回调
满足一些需要对HttpServer通讯层socket套接字hio做一些业务处理或计数器需求。

### 优化 http 默认处理程序路径安全检查性能和流程
### 内部 http 路径安全检查导出至 HttpRequest::CheckPathSafe
主要解决不同的处理链对安全检查有不同的需求，可在业务headerHandler回调中自由加入新的处理逻辑或改变ctx->request 已经做的path_safe安全检查结果使其忽略某些因hv内部判定原因触发的终止请求，也便于业务无需重复开发检查可调用内置的安检path功能，同时优化未统一管理检查导致多个地方重复的对字符做unescape解码以及字符遍历检查造成的维护分散和性能损耗。

### 优化 http 服务器相对路径文件缓存映射键
### 在 hurl.h 中添加 hv::compressRelativePath 函数
因为内部文件缓存map的key是文件路径，而未经压缩处理的相对路径格式存在对相同的文件形成无数种字符变化，易造成原本个位数的真实有效文件被外网恶意请求分配出无数个文件缓存造成内存影响，同时也避免了Windows相比Linux的路径兼容性严格程度不同导致的末尾反斜杠不应该访问成功的请求却能够open成功。

### 修复误报“/..file”正常路径错误
解决某些文件确实前面几个点符号造成被误判为相对父路径从而终止了请求。

### 修复 defaultLargeFileHandler 在Windows环境不支持中文
### 在 hstring.h 中添加 hv::utf8_to_ansi 和 hv::ansi_to_utf8 函数
因为这个内部的大文件处理是采用的HFile封装的标准库ANSI函数处理，而通常只有Windows环境的ANSI不是UTF8编码，所以为了改动幅度最小化并且避免引入iconv外部第三方编码转换库只好借助内置的窄宽字符转换先将浏览器请求的UTF8字符串转换到宽字符，在从宽字符转换到对应本地化编码的ANSI，虽然存在两次转换但大文件传输并不高频触发影响不大，为了方便后续Windows环境有这方面转换需要都整合到hstring.h中了。

### 优化部分日志级别和消息描述
某些日志内容完全一样不易区分而且没有携带ip,port,ssl具体错误这样的此类重要信息所以调整了下描述内容，还有些与Server处理强相关的fprintf(stderr)输出的错误会因外部高频请求造成频繁输出在shell便调整到hlog默认日志模块记录了。