### PR TITLE
增强&优化&修复一些主要涉及HttpServer业务的使用

### DIFF
--- a/base/hbase.c
+++ b/base/hbase.c
@@ -521,22 +521,84 @@ int hv_parse_url(hurl_t* stURL, const char* strURL) {
     if (ep == end) return 0;
     // /path
     sp = ep;
-    ep = strchr(sp, '?');
-    if (ep == NULL) ep = end;
+    const char* query = strchr(sp, '?');
+    const char* fragment = strchr(sp, '#');
+    if (query && fragment) ep = MIN(query, fragment);
+    else if (query == NULL && fragment) ep = fragment;
+    else if (query == NULL) ep = end;
+    else ep = query;
     stURL->fields[HV_URL_PATH].off = sp - begin;
     stURL->fields[HV_URL_PATH].len = ep - sp;
     if (ep == end) return 0;
-    // ?query
-    sp = ep + 1;
-    ep = strchr(sp, '#');
-    if (ep == NULL) ep = end;
-    stURL->fields[HV_URL_QUERY].off = sp - begin;
-    stURL->fields[HV_URL_QUERY].len = ep - sp;
-    if (ep == end) return 0;
+    if (ep != fragment) {
+        // ?query
+        sp = ep + 1;
+        ep = fragment;
+        if (ep == NULL) ep = end;
+        stURL->fields[HV_URL_QUERY].off = sp - begin;
+        stURL->fields[HV_URL_QUERY].len = ep - sp;
+        if (ep == end) return 0;
+    }
     // #fragment
     sp = ep + 1;
     ep = end;
     stURL->fields[HV_URL_FRAGMENT].off = sp - begin;
     stURL->fields[HV_URL_FRAGMENT].len = ep - sp;
     return 0;
+}
+
+int hv_normalize_path(char *path) {
+    if (*path != '/') return 0;
+    int pos = 1;
+#ifdef OS_WIN
+    int sum = 0;
+#endif
+    for (int i = 1; path[i] != '\0'; ++i) {
+        switch (path[i]) {
+            case '\\':
+            case '/':
+                if (path[pos - 1] != '/') path[pos++] = '/';
+                break;
+
+            case '.':
+                if (path[pos - 1] == '/') {
+                    if (path[i + 1] == '.' && (path[i + 2] == '/' || path[i + 2] == '\\' || path[i + 2] == '\0')) {
+                        while (--pos > 0) {
+                            if (path[pos - 1] == '/') break;
+                        }
+                        if (pos < 1) return 0;
+                        i += path[i + 2] == '\0' ? 1 : 2;
+                        break;
+                    }
+                    if (path[i + 1] == '\0') break;
+                    if (path[i + 1] == '/' || path[i + 1] == '\\') {
+                        ++i;
+                        break;
+                    }
+                }
+                path[pos++] = '.';
+#ifdef OS_WIN
+                // windows does not have a trailing '.'
+                sum = 1;
+                while (path[i + sum] == '.') {
+                    path[pos++] = '.';
+                    ++sum;
+                }
+                if (path[i + sum] == '\0') pos -= sum;
+                i += sum - 1;
+#endif
+                break;
+
+            default:
+#ifdef OS_WIN
+                // windows is not case sensitive
+                path[pos++] = (char)tolower(path[i]);
+#else
+                path[pos++] = path[i];
+#endif
+                break;
+        }
+    }
+    path[pos] = '\0';
+    return pos;
 }

--- a/base/hbase.h
+++ b/base/hbase.h
@@ -140,6 +140,8 @@ typedef struct hurl_s {
 
 HV_EXPORT int hv_parse_url(hurl_t* stURL, const char* strURL);
 
+HV_EXPORT int hv_normalize_path(char *path);
+
 END_EXTERN_C
 
 #endif // HV_BASE_H_

--- a/cpputil/hstring.cpp
+++ b/cpputil/hstring.cpp
@@ -226,24 +226,25 @@ std::string NetAddr::to_string(const char* ip, int port) {
 }
 
 #ifdef OS_WIN
-std::string wchar_to_utf8(const std::wstring &wstr) {
+std::string wchar_to_string(const UINT codePage, const std::wstring &wstr) {
   std::string str(4 * wstr.size() + 1, '\0');
   str.resize(WideCharToMultiByte(
-    CP_UTF8, 0, 
-    wstr.c_str(), wstr.size(), 
-    const_cast<char*>(str.data()), str.size(), 
+    codePage, 0,
+    wstr.c_str(), wstr.size(),
+    const_cast<char*>(str.data()), str.size(),
     NULL, NULL));
   return str;
 }
 
-std::wstring utf8_to_wchar(const std::string &str) {
-  std::wstring wstr(2 * str.size() + 1, '\0');
+std::wstring string_to_wchar(const UINT codePage, const std::string &str) {
+  std::wstring wstr(2 * str.size() + 2, '\0');
   wstr.resize(MultiByteToWideChar(
-    CP_UTF8, 0, 
-    str.c_str(), str.size(), 
+    codePage, 0,
+    str.c_str(), str.size(),
     const_cast<wchar_t*>(wstr.data()), wstr.size()));
   return wstr;
 }
+
 #endif // OS_WIN
 
 } // end namespace hv

--- a/cpputil/hstring.h
+++ b/cpputil/hstring.h
@@ -88,10 +88,31 @@ struct HV_EXPORT NetAddr {
     static std::string to_string(const char* ip, int port);
 };
 
-// windows wchar and utf8 conver
+// windows wchar and utf8/ansi conver
 #ifdef OS_WIN
-HV_EXPORT std::string wchar_to_utf8(const std::wstring &wstr);
-HV_EXPORT std::wstring utf8_to_wchar(const std::string &str);
+HV_EXPORT std::string wchar_to_string(const UINT codePage, const std::wstring &wstr);
+HV_EXPORT std::wstring string_to_wchar(const UINT codePage, const std::string &str);
+
+HV_INLINE std::string wchar_to_utf8(const std::wstring &wstr) {
+    return wchar_to_string(CP_UTF8, wstr);
+}
+
+HV_INLINE std::string wchar_to_ansi(const std::wstring &wstr) {
+    return wchar_to_string(CP_ACP, wstr);
+}
+
+HV_INLINE std::wstring utf8_to_wchar(const std::string &str) {
+    return string_to_wchar(CP_UTF8, str);
+}
+
+HV_INLINE std::string utf8_to_ansi(const std::string &str) {
+    return wchar_to_string(CP_ACP, string_to_wchar(CP_UTF8, str));
+}
+
+HV_INLINE std::string ansi_to_utf8(const std::string &str) {
+    return wchar_to_string(CP_UTF8, string_to_wchar(CP_ACP, str));
+}
+
 #endif // OS_WIN
 
 } // end namespace hv

--- a/docs/cn/HttpServer.md
+++ b/docs/cn/HttpServer.md
@@ -93,10 +93,11 @@ class HttpService {
     // 返回注册的路由路径列表
     hv::StringList Paths();
 
-    // 处理流程：前处理器 -> 中间件 -> 处理器 -> 后处理器
-    // preprocessor -> middleware -> processor -> postprocessor
+    // 处理流程：标头处理器 -> 前处理器 -> 中间件 -> 处理器 -> 后处理器
+    // headerHandler -> preprocessor -> middleware -> processor -> postprocessor
 
     // 数据成员
+    http_handler    headerHandler;  // 标头处理器
     http_handler    preprocessor;   // 前处理器
     http_handlers   middleware;     // 中间件
     http_handler    processor;      // 处理器

--- a/event/hevent.c
+++ b/event/hevent.c
@@ -602,7 +602,7 @@ static void __write_timeout_cb(htimer_t* timer) {
         if (io->io_type & HIO_TYPE_SOCKET) {
             char localaddrstr[SOCKADDR_STRLEN] = {0};
             char peeraddrstr[SOCKADDR_STRLEN] = {0};
-            hlogw("write timeout [%s] <=> [%s]",
+            hlogi("write timeout [%s] <=> [%s]",
                     SOCKADDR_STR(io->localaddr, localaddrstr),
                     SOCKADDR_STR(io->peeraddr, peeraddrstr));
         }

--- a/event/nio.c
+++ b/event/nio.c
@@ -80,7 +80,7 @@ static void ssl_server_handshake(hio_t* io) {
         }
     }
     else {
-        hloge("ssl handshake failed: %d", ret);
+        hloge("ssl server handshake failed: %d", ret);
         io->error = ERR_SSL_HANDSHAKE;
         hio_close(io);
     }
@@ -101,7 +101,7 @@ static void ssl_client_handshake(hio_t* io) {
         }
     }
     else {
-        hloge("ssl handshake failed: %d", ret);
+        hloge("ssl client handshake failed: %d", ret);
         io->error = ERR_SSL_HANDSHAKE;
         hio_close(io);
     }

--- a/examples/httpd/handler.cpp
+++ b/examples/httpd/handler.cpp
@@ -9,10 +9,8 @@
 #include "hstring.h"
 #include "EventLoop.h" // import setTimeout, setInterval
 
-int Handler::preprocessor(HttpRequest* req, HttpResponse* resp) {
+int Handler::headerHandler(HttpRequest* req, HttpResponse* resp) {
     // printf("%s:%d\n", req->client_addr.ip.c_str(), req->client_addr.port);
-    // printf("%s\n", req->Dump(true, true).c_str());
-
 #if REDIRECT_HTTP_TO_HTTPS
     // 301
     if (req->scheme == "http") {
@@ -25,6 +23,11 @@ int Handler::preprocessor(HttpRequest* req, HttpResponse* resp) {
     // if (req->content_type != APPLICATION_JSON) {
     //     return response_status(resp, HTTP_STATUS_BAD_REQUEST);
     // }
+    return HTTP_STATUS_NEXT;
+}
+
+int Handler::preprocessor(HttpRequest* req, HttpResponse* resp) {
+    // printf("%s\n", req->Dump(true, true).c_str());
 
     // Deserialize request body to json, form, etc.
     req->ParseBody();

--- a/examples/httpd/handler.h
+++ b/examples/httpd/handler.h
@@ -5,7 +5,8 @@
 
 class Handler {
 public:
-    // preprocessor => middleware -> handlers => postprocessor
+    // headerHandler => preprocessor => middleware -> handlers => postprocessor
+    static int headerHandler(HttpRequest* req, HttpResponse* resp);
     static int preprocessor(HttpRequest* req, HttpResponse* resp);
     static int postprocessor(HttpRequest* req, HttpResponse* resp);
     static int errorHandler(const HttpContextPtr& ctx);

--- a/examples/httpd/router.cpp
+++ b/examples/httpd/router.cpp
@@ -7,8 +7,9 @@
 
 void Router::Register(hv::HttpService& router) {
     /* handler chain */
-    // preprocessor -> middleware -> processor -> postprocessor
+    // headerHandler -> preprocessor -> middleware -> processor -> postprocessor
     // processor: pathHandlers -> staticHandler -> errorHandler
+    router.headerHandler = Handler::headerHandler;
     router.preprocessor = Handler::preprocessor;
     router.postprocessor = Handler::postprocessor;
     // router.errorHandler = Handler::errorHandler;

--- a/http/HttpMessage.cpp
+++ b/http/HttpMessage.cpp
@@ -92,7 +92,7 @@ bool HttpCookie::parse(const std::string& str) {
                 httponly = true;
             }
             else {
-                hlogw("Unrecognized key '%s'", key.c_str());
+                hlogi("Cookie Unrecognized key '%s'", key.c_str());
             }
         }
 

--- a/http/HttpParser.cpp
+++ b/http/HttpParser.cpp
@@ -2,6 +2,7 @@
 
 #include "Http1Parser.h"
 #include "Http2Parser.h"
+#include "hlog.h"
 
 HttpParser* HttpParser::New(http_session_type type, http_version version) {
     HttpParser* hp = NULL;
@@ -12,7 +13,7 @@ HttpParser* HttpParser::New(http_session_type type, http_version version) {
 #ifdef WITH_NGHTTP2
         hp = new Http2Parser(type);
 #else
-        fprintf(stderr, "Please recompile WITH_NGHTTP2!\n");
+        hlogi("Please recompile WITH_NGHTTP2!\n");
 #endif
     }
 

--- a/http/server/HttpHandler.h
+++ b/http/server/HttpHandler.h
@@ -51,6 +51,7 @@ public:
 
     // for http
     hio_t                   *io;
+    void                    *server;
     HttpService             *service;
     HttpRequestPtr          req;
     HttpResponsePtr         resp;
@@ -143,7 +144,7 @@ public:
 
 private:
     const HttpContextPtr& context();
-    int   handleRequestHeaders();
+    void  handleRequestHeaders();
     // Expect: 100-continue
     void  handleExpect100();
     void  addResponseHeaders();
@@ -156,7 +157,7 @@ private:
     // default handlers
     int defaultRequestHandler();
     int defaultStaticHandler();
-    int defaultLargeFileHandler();
+    int defaultLargeFileHandler(const std::string &filepath);
     int defaultErrorHandler();
     int customHttpHandler(const http_handler& handler);
     int invokeHttpHandler(const http_handler* handler);

--- a/http/server/HttpServer.h
+++ b/http/server/HttpServer.h
@@ -29,6 +29,8 @@ typedef struct http_server_s {
     // hooks
     std::function<void()> onWorkerStart;
     std::function<void()> onWorkerStop;
+    std::function<bool(hio_t* io)> onAccept;
+    std::function<void(hio_t* io)> onClose;
     // SSL/TLS
     hssl_ctx_t  ssl_ctx;
     unsigned    alloced_ssl_ctx: 1;

--- a/http/server/HttpService.h
+++ b/http/server/HttpService.h
@@ -34,6 +34,7 @@
  */
 #define HTTP_STATUS_NEXT        0
 #define HTTP_STATUS_UNFINISHED  0
+#define HTTP_STATUS_WANT_CLOSE  1
 // NOTE: http_sync_handler run on IO thread
 typedef std::function<int(HttpRequest* req, HttpResponse* resp)>                            http_sync_handler;
 // NOTE: http_async_handler run on hv::async threadpool
@@ -108,7 +109,8 @@ namespace hv {
 
 struct HV_EXPORT HttpService {
     /* handler chain */
-    // preprocessor -> middleware -> processor -> postprocessor
+    // headerHandler -> preprocessor -> middleware -> processor -> postprocessor
+    http_handler        headerHandler;
     http_handler        preprocessor;
     http_handlers       middleware;
     // processor: pathHandlers -> staticHandler -> errorHandler

--- a/ssl/openssl.c
+++ b/ssl/openssl.c
@@ -1,5 +1,5 @@
 #include "hssl.h"
-
+#include "hlog.h"
 #ifdef WITH_OPENSSL
 
 #include "openssl/ssl.h"
@@ -117,6 +117,12 @@ int hssl_accept(hssl_t ssl) {
     else if (err == SSL_ERROR_WANT_WRITE) {
         return HSSL_WANT_WRITE;
     }
+    else if (err == SSL_ERROR_SYSCALL) {
+        hloge("SSL_accept errno:%d,error:%s", errno, strerror(errno));
+    }
+    else {
+        hloge("SSL_accept: %s", ERR_error_string(ERR_get_error(), NULL));
+    }
     return err;
 }
 
@@ -130,6 +136,12 @@ int hssl_connect(hssl_t ssl) {
     }
     else if (err == SSL_ERROR_WANT_WRITE) {
         return HSSL_WANT_WRITE;
+    }
+    else if (err == SSL_ERROR_SYSCALL) {
+        hloge("SSL_connect errno:%d,error:%s", errno, strerror(errno));
+    }
+    else {
+        hloge("SSL_connect: %s", ERR_error_string(ERR_get_error(), NULL));
     }
     return err;
 }


### PR DESCRIPTION
### 支持自定义 http 处理链 headerHandler
能够在内部一些默认处理之前最优先做业务处理，例如需要对请求头或Host域做检查，如果不合法可忽略hv内部的RecvBody，Expect100，Proxy，ProtocolUpgrade等等一系列的内置处理，也可提前做个性化的rewrite头部信息从而影响hv后续的一些默认处理行为。

### 支持 http 处理程序链返回 HTTP_STATUS_WANT_CLOSE
能够在各个处理链线程安全的通过返回此值要求无视Http头keep-alive强制关闭连接，甚至可选搭配处理链的回调中将ctx->writer->state = hv::HttpResponseWriter::SEND_END; 实现取消hv内部默认响应http状态包变为自定义响应非http报文或不响应任何数据，让非法访问无法探测外网端口的具体服务性质。

### 支持 http 服务器绑定 onAccept 和 onClose 回调
满足一些需要对HttpServer通讯层socket套接字hio做一些业务处理或计数器需求。

### 支持 http 合法相对路径请求
### 优化 http 请求路径安全检查性能和流程
### 优化 http 服务器相对路径文件缓存映射键
因为内部文件缓存map的key是文件路径，而未经规范化处理的路径格式存在对相同的文件形成无数种字符变化，易造成原本个位数的真实有效文件被外网恶意请求分配出无数个文件缓存造成内存影响，同时也避免了Windows相比Linux的路径兼容性严格程度不同导致的末尾反斜杠不应该访问成功的请求却能够open成功。

### 添加 hv_normalize_path 函数到 hbase.h
实用的文件路径规范化修剪处理函数解决上述路径相关问题的关键实现。

### 修复误报“/..file”正常文件路径 bug
解决某些文件确实前面几个点符号造成被误判为相对父路径从而终止了请求。

### 修复 hv_parse_url 处理 '#' 和 '?' 顺序优先级 bug
解决类似“/xxx/xxx.htm#xxx?xxxx”的顺序导致解析结果有错误。

### 修复 defaultLargeFileHandler 在Windows环境不支持中文
### 在 hstring.h 中添加 hv::utf8_to_ansi 和 hv::ansi_to_utf8 函数
因为这个内部的大文件处理是采用的HFile封装的标准库ANSI函数处理，而通常只有Windows环境的ANSI不是UTF8编码，所以为了改动幅度最小化并且避免引入iconv外部第三方编码转换库只好借助内置的窄宽字符转换先将浏览器请求的UTF8字符串转换到宽字符，在从宽字符转换到对应本地化编码的ANSI，虽然存在两次转换但大文件传输并不高频触发影响不大，为了方便后续Windows环境有这方面转换需要都整合到hstring.h中了。

### 优化部分日志级别和消息描述
某些日志内容完全一样不易区分而且没有携带ip,port,ssl具体错误这样的此类重要信息所以调整了下描述内容，还有些与Server处理强相关的fprintf(stderr)输出的错误会因外部高频请求造成频繁输出在shell便调整到hlog默认日志模块记录了。