### PR TITLE
支持自定义 http 处理链 headerHandler

### DIFF
--- a/docs/cn/HttpServer.md
+++ b/docs/cn/HttpServer.md
@@ -93,10 +93,11 @@ class HttpService {
     // 返回注册的路由路径列表
     hv::StringList Paths();
 
-    // 处理流程：前处理器 -> 中间件 -> 处理器 -> 后处理器
-    // preprocessor -> middleware -> processor -> postprocessor
+    // 处理流程：标头处理器 -> 前处理器 -> 中间件 -> 处理器 -> 后处理器
+    // headerHandler -> preprocessor -> middleware -> processor -> postprocessor
 
     // 数据成员
+    http_handler    headerHandler;  // 标头处理器
     http_handler    preprocessor;   // 前处理器
     http_handlers   middleware;     // 中间件
     http_handler    processor;      // 处理器

--- a/examples/httpd/handler.cpp
+++ b/examples/httpd/handler.cpp
@@ -9,10 +9,8 @@
 #include "hstring.h"
 #include "EventLoop.h" // import setTimeout, setInterval
 
-int Handler::preprocessor(HttpRequest* req, HttpResponse* resp) {
+int Handler::headerHandler(HttpRequest* req, HttpResponse* resp) {
     // printf("%s:%d\n", req->client_addr.ip.c_str(), req->client_addr.port);
-    // printf("%s\n", req->Dump(true, true).c_str());
-
 #if REDIRECT_HTTP_TO_HTTPS
     // 301
     if (req->scheme == "http") {
@@ -25,6 +23,11 @@ int Handler::preprocessor(HttpRequest* req, HttpResponse* resp) {
     // if (req->content_type != APPLICATION_JSON) {
     //     return response_status(resp, HTTP_STATUS_BAD_REQUEST);
     // }
+    return HTTP_STATUS_NEXT;
+}
+
+int Handler::preprocessor(HttpRequest* req, HttpResponse* resp) {
+    // printf("%s\n", req->Dump(true, true).c_str());
 
     // Deserialize request body to json, form, etc.
     req->ParseBody();

--- a/examples/httpd/handler.h
+++ b/examples/httpd/handler.h
@@ -5,7 +5,8 @@
 
 class Handler {
 public:
-    // preprocessor => middleware -> handlers => postprocessor
+    // headerHandler => preprocessor => middleware -> handlers => postprocessor
+    static int headerHandler(HttpRequest* req, HttpResponse* resp);
     static int preprocessor(HttpRequest* req, HttpResponse* resp);
     static int postprocessor(HttpRequest* req, HttpResponse* resp);
     static int errorHandler(const HttpContextPtr& ctx);

--- a/examples/httpd/router.cpp
+++ b/examples/httpd/router.cpp
@@ -7,8 +7,9 @@
 
 void Router::Register(hv::HttpService& router) {
     /* handler chain */
-    // preprocessor -> middleware -> processor -> postprocessor
+    // headerHandler -> preprocessor -> middleware -> processor -> postprocessor
     // processor: pathHandlers -> staticHandler -> errorHandler
+    router.headerHandler = Handler::headerHandler;
     router.preprocessor = Handler::preprocessor;
     router.postprocessor = Handler::postprocessor;
     // router.errorHandler = Handler::errorHandler;

--- a/http/server/HttpHandler.h
+++ b/http/server/HttpHandler.h
@@ -143,7 +143,7 @@ public:
 
 private:
     const HttpContextPtr& context();
-    int   handleRequestHeaders();
+    void  handleRequestHeaders();
     // Expect: 100-continue
     void  handleExpect100();
     void  addResponseHeaders();

--- a/http/server/HttpService.h
+++ b/http/server/HttpService.h
@@ -108,7 +108,8 @@ namespace hv {
 
 struct HV_EXPORT HttpService {
     /* handler chain */
-    // preprocessor -> middleware -> processor -> postprocessor
+    // headerHandler -> preprocessor -> middleware -> processor -> postprocessor
+    http_handler        headerHandler;
     http_handler        preprocessor;
     http_handlers       middleware;
     // processor: pathHandlers -> staticHandler -> errorHandler


### PR DESCRIPTION
能够在内部一些默认处理之前最优先做业务处理，例如需要对请求头或Host域做检查，如果不合法可忽略hv内部的RecvBody，Expect100，Proxy，ProtocolUpgrade等等一系列的内置处理，也可提前做个性化的rewrite头部信息从而影响hv后续的一些默认处理行为，顺便优化了 http 请求路径安全检查性能和流程。