### PR TITLE
支持 http 处理链返回 HTTP_STATUS_WANT_CLOSE

### DIFF
--- a/http/server/HttpService.h
+++ b/http/server/HttpService.h
@@ -34,6 +34,7 @@
  */
 #define HTTP_STATUS_NEXT        0
 #define HTTP_STATUS_UNFINISHED  0
+#define HTTP_STATUS_WANT_CLOSE  1
 // NOTE: http_sync_handler run on IO thread
 typedef std::function<int(HttpRequest* req, HttpResponse* resp)>                            http_sync_handler;
 // NOTE: http_async_handler run on hv::async threadpool


### PR DESCRIPTION
能够在各个处理链线程安全的通过返回此值要求无视Http头keep-alive强制关闭连接，甚至可选搭配处理链的回调中将ctx->writer->state = hv::HttpResponseWriter::SEND_END; 实现取消hv内部默认响应http状态包变为自定义响应非http报文或不响应任何数据，让非法访问无法探测外网端口的具体服务性质。