### PR TITLE
改善 http 服务请求路径相关的一些缺陷

### DIFF
--- a/base/hbase.c
+++ b/base/hbase.c
@@ -4,6 +4,7 @@
 #include <mach-o/dyld.h> // for _NSGetExecutablePath
 #endif
 
+#include <ctype.h>  // for tolower
 #include "hatomic.h"
 
 #ifndef RAND_MAX
@@ -542,6 +543,7 @@ int hv_parse_url(hurl_t* stURL, const char* strURL) {
 }
 
 int hv_normalize_path(char *path) {
+    if (!path) return 0;
     if (*path != '/') return 0;
     int pos = 1;
 #ifdef OS_WIN
@@ -586,7 +588,7 @@ int hv_normalize_path(char *path) {
             default:
 #ifdef OS_WIN
                 // windows is not case sensitive
-                path[pos++] = (char)tolower(path[i]);
+                path[pos++] = (char)tolower((unsigned char)path[i]);
 #else
                 path[pos++] = path[i];
 #endif

--- a/base/hbase.h
+++ b/base/hbase.h
@@ -140,6 +140,8 @@ typedef struct hurl_s {
 
 HV_EXPORT int hv_parse_url(hurl_t* stURL, const char* strURL);
 
+HV_EXPORT int hv_normalize_path(char *path);
+
 END_EXTERN_C
 
 #endif // HV_BASE_H_

--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -524,14 +524,15 @@ int HttpHandler::defaultRequestHandler() {
 int HttpHandler::defaultStaticHandler() {
     // file service
     std::string path = req->Path();
-    const char* req_path = path.c_str();
-    // path safe check
-    if (req_path[0] != '/' || strstr(req_path, "/..") || strstr(req_path, "\\..")) {
+    path.resize(hv_normalize_path(const_cast<char*>(path.c_str())));
+    if (path.empty()) {
+        hloge("[%s:%d] Illegal relative path: %s", ip, port, req->path.c_str());
         return HTTP_STATUS_BAD_REQUEST;
     }
 
+    const char* req_path = path.c_str();
     std::string filepath;
-    bool is_dir = path.back() == '/' &&
+    const bool is_dir = path.back() == '/' &&
                   service->index_of.size() > 0 &&
                   hv_strstartswith(req_path, service->index_of.c_str());
     if (is_dir) {

--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -524,7 +524,9 @@ int HttpHandler::defaultRequestHandler() {
 int HttpHandler::defaultStaticHandler() {
     // file service
     std::string path = req->Path();
-    path.resize(hv_normalize_path(const_cast<char*>(path.c_str())));
+    if (!path.empty()) {
+        path.resize(hv_normalize_path(&path[0]));
+    }
     if (path.empty()) {
         hloge("[%s:%d] Illegal relative path: %s", ip, port, req->path.c_str());
         return HTTP_STATUS_BAD_REQUEST;


### PR DESCRIPTION
### 添加 hv_normalize_path 函数到 hbase.h
实用的文件路径规范化修剪处理函数，解决路径相关缺陷的关键实现。

### 支持 http 合法相对路径请求
### 优化 http 服务器相对路径文件缓存映射键
因为内部文件缓存map的key是文件路径，而未经规范化处理的路径格式存在对相同的文件形成无数种字符变化，易造成原本个位数的真实有效文件被外网恶意请求分配出无数个文件缓存造成内存影响，同时也避免了Windows相比Linux的路径兼容性严格程度不同导致的末尾反斜杠不应该访问成功的请求却能够open成功。

### 修复误报“/..file”正常文件路径 bug
某些文件确实前面几个点符号造成被误判为相对父路径从而终止了请求。