### PR TITLE
优化部分日志级别和消息描述

### DIFF
--- a/event/hevent.c
+++ b/event/hevent.c
@@ -602,7 +602,7 @@ static void __write_timeout_cb(htimer_t* timer) {
         if (io->io_type & HIO_TYPE_SOCKET) {
             char localaddrstr[SOCKADDR_STRLEN] = {0};
             char peeraddrstr[SOCKADDR_STRLEN] = {0};
-            hlogw("write timeout [%s] <=> [%s]",
+            hlogi("write timeout [%s] <=> [%s]",
                     SOCKADDR_STR(io->localaddr, localaddrstr),
                     SOCKADDR_STR(io->peeraddr, peeraddrstr));
         }

--- a/event/nio.c
+++ b/event/nio.c
@@ -80,7 +80,7 @@ static void ssl_server_handshake(hio_t* io) {
         }
     }
     else {
-        hloge("ssl handshake failed: %d", ret);
+        hloge("ssl server handshake failed: %d", ret);
         io->error = ERR_SSL_HANDSHAKE;
         hio_close(io);
     }
@@ -101,7 +101,7 @@ static void ssl_client_handshake(hio_t* io) {
         }
     }
     else {
-        hloge("ssl handshake failed: %d", ret);
+        hloge("ssl client handshake failed: %d", ret);
         io->error = ERR_SSL_HANDSHAKE;
         hio_close(io);
     }

--- a/http/HttpMessage.cpp
+++ b/http/HttpMessage.cpp
@@ -92,7 +92,7 @@ bool HttpCookie::parse(const std::string& str) {
                 httponly = true;
             }
             else {
-                hlogw("Unrecognized key '%s'", key.c_str());
+                hlogi("Cookie Unrecognized key '%s'", key.c_str());
             }
         }
 

--- a/http/HttpParser.cpp
+++ b/http/HttpParser.cpp
@@ -2,6 +2,7 @@
 
 #include "Http1Parser.h"
 #include "Http2Parser.h"
+#include "hlog.h"
 
 HttpParser* HttpParser::New(http_session_type type, http_version version) {
     HttpParser* hp = NULL;
@@ -12,7 +13,7 @@ HttpParser* HttpParser::New(http_session_type type, http_version version) {
 #ifdef WITH_NGHTTP2
         hp = new Http2Parser(type);
 #else
-        fprintf(stderr, "Please recompile WITH_NGHTTP2!\n");
+        hlogi("Please recompile WITH_NGHTTP2!\n");
 #endif
     }
 

--- a/ssl/openssl.c
+++ b/ssl/openssl.c
@@ -1,5 +1,5 @@
 #include "hssl.h"
-
+#include "hlog.h"
 #ifdef WITH_OPENSSL
 
 #include "openssl/ssl.h"
@@ -117,6 +117,12 @@ int hssl_accept(hssl_t ssl) {
     else if (err == SSL_ERROR_WANT_WRITE) {
         return HSSL_WANT_WRITE;
     }
+    else if (err == SSL_ERROR_SYSCALL) {
+        hloge("SSL_accept errno:%d,error:%s", errno, strerror(errno));
+    }
+    else {
+        hloge("SSL_accept: %s", ERR_error_string(ERR_get_error(), NULL));
+    }
     return err;
 }
 
@@ -130,6 +136,12 @@ int hssl_connect(hssl_t ssl) {
     }
     else if (err == SSL_ERROR_WANT_WRITE) {
         return HSSL_WANT_WRITE;
+    }
+    else if (err == SSL_ERROR_SYSCALL) {
+        hloge("SSL_connect errno:%d,error:%s", errno, strerror(errno));
+    }
+    else {
+        hloge("SSL_connect: %s", ERR_error_string(ERR_get_error(), NULL));
     }
     return err;
 }


### PR DESCRIPTION
主要优化某些日志等级不合适且内容完全一样不易区分还没有携带较重要的参数信息，以及ssl握手错误太含糊所以补充了openssl具体错误原因，还有些与Server请求处理强相关的fprintf(stderr)输出的错误会因外部高频恶意请求造成频繁输出在shell便调整到hlog日志模块记录了。