### PR TITLE
支持hmain兼容windows非控制台以及linux gui程序

### DIFF
--- a/base/hmain.h
+++ b/base/hmain.h
@@ -12,6 +12,8 @@
 
 BEGIN_EXTERN_C
 
+typedef int (*printf_t)(const char *const fmt, ...);
+
 typedef struct main_ctx_s {
     char    run_dir[MAX_PATH];
     char    program_name[MAX_PATH];
@@ -94,6 +96,7 @@ HV_EXPORT pid_t getpid_from_pidfile();
 // signal=[start,stop,restart,status,reload]
 HV_EXPORT int  signal_init(procedure_t reload_fn DEFAULT(NULL), void* reload_userdata DEFAULT(NULL));
 HV_EXPORT void signal_handle(const char* signal);
+HV_EXPORT bool signal_handle_noexit(const char* signal);
 #ifdef OS_UNIX
 // we use SIGTERM to quit process, SIGUSR1 to reload confile
 #define SIGNAL_TERMINATE    SIGTERM
@@ -105,6 +108,7 @@ void signal_handler(int signo);
 #define DEFAULT_WORKER_PROCESSES    4
 #define MAXNUM_WORKER_PROCESSES     256
 HV_EXPORT extern main_ctx_t   g_main_ctx;
+HV_EXPORT extern printf_t     printf_fn;
 
 // master-workers processes
 HV_EXPORT int master_workers_run(


### PR DESCRIPTION
### 添加hmain signal_handle_noexit函数
因为signal_handle内部自动exit结束程序，而当业务层需要在exit之前做一些操作(例如执行打开正在运行的http服务首页url)，因此需要支持一个不自动exit的函数版本。

### 支持自定义设置hmain内部msg信息 printf函数指针
因为不是所有程序都是控制台程序，而非控制台程序需要采用MessageBox或其他信息渲染方式来提示信息，因此需要支持自定义设置hmain使用的printf函数指针接管后由用户业务层采用其他形式进行提示。