### PR TITLE
fix HttpServer::loop idx iteration exception

### DIFF
--- a/http/server/HttpServer.cpp
+++ b/http/server/HttpServer.cpp
@@ -296,12 +296,14 @@ std::shared_ptr<hv::EventLoop> HttpServer::loop(int idx) {
     if (privdata == NULL) return NULL;
     std::lock_guard<std::mutex> locker(privdata->mutex_);
     if (privdata->loops.empty()) return NULL;
-    if (idx >= 0 && idx < (int)privdata->loops.size()) {
-        return privdata->loops[idx];
+    if (idx < 0) {
+        EventLoop* cur = currentThreadEventLoop;
+        for (auto& loop : privdata->loops) {
+            if (loop.get() == cur) return loop;
+        }
     }
-    EventLoop* cur = currentThreadEventLoop;
-    for (auto& loop : privdata->loops) {
-        if (loop.get() == cur) return loop;
+    else if (idx >= 0 && idx < (int)privdata->loops.size()) {
+        return privdata->loops[idx];
     }
     return NULL;
 }


### PR DESCRIPTION
```c
for (int idx = 0; ; ++idx) {
    loop = m_server.loop(idx);
    if (!loop) break;
    ....
}
```
类似上述迭代获取loop会在非loop线程内不会死循环，在loop线程内死循环，而多进程模式也不好计算privdata->loops内部私有数组实际数量，不同线程环境行为不一致和idx语义有歧义所以调整了超出idx最大范围时返回NULL