### PR TITLE
feat: support http client reuse external loop

### DIFF
--- a/http/client/HttpClient.cpp
+++ b/http/client/HttpClient.cpp
@@ -1,5 +1,6 @@
 #include "HttpClient.h"
 
+#include <memory>
 #include <mutex>
 
 #ifdef WITH_CURL
@@ -731,3 +732,10 @@ int http_client_send_async(HttpRequestPtr req, HttpResponseCallback resp_cb) {
 
     return http_client_exec_async(hv_default_async_http_client(), req, std::move(resp_cb));
 }
+
+int http_client_reuse_loop(http_client_t *cli, hv::EventLoopPtr loop) {
+    if (!cli || !loop) return ERR_NULL_POINTER;
+    cli->async_client_ = std::make_shared<hv::AsyncHttpClient>(std::move(loop));
+    return 0;
+}
+

--- a/http/client/HttpClient.h
+++ b/http/client/HttpClient.h
@@ -1,6 +1,7 @@
 #ifndef HV_HTTP_CLIENT_H_
 #define HV_HTTP_CLIENT_H_
 
+#include "EventLoop.h"
 #include "hexport.h"
 #include "hssl.h"
 #include "HttpMessage.h"
@@ -76,6 +77,7 @@ HV_EXPORT int http_client_send_data(http_client_t* cli, const char* data, int si
 HV_EXPORT int http_client_recv_data(http_client_t* cli, char* data, int size);
 HV_EXPORT int http_client_recv_response(http_client_t* cli, HttpResponse* resp);
 HV_EXPORT int http_client_close(http_client_t* cli);
+HV_EXPORT int http_client_reuse_loop(http_client_t *cli, hv::EventLoopPtr loop);
 
 namespace hv {
 
@@ -160,6 +162,10 @@ public:
     }
     int close() {
         return http_client_close(_client);
+    }
+    //if need, set once, set before sendAsync
+    int reuseLoop(EventLoopPtr loop) {
+        return http_client_reuse_loop(_client, std::move(loop));
     }
 
 private:


### PR DESCRIPTION
Users may want to control which loop is used in HttpClient to handle responses, so they can create fewer threads and write less code for managing concurrency.