### PR TITLE
fix: loss notify when HThreadPool::stop()

### DIFF
--- a/cmake/vars.cmake
+++ b/cmake/vars.cmake
@@ -65,6 +65,7 @@ set(EVPP_HEADERS
     evpp/TcpServer.h
     evpp/UdpClient.h
     evpp/UdpServer.h
+    evpp/TimerThread.h
 )
 
 set(PROTOCOL_HEADERS

--- a/cpputil/hthreadpool.h
+++ b/cpputil/hthreadpool.h
@@ -80,7 +80,10 @@ public:
 
     int stop() {
         if (status == STOP) return -1;
-        status = STOP;
+        {
+            std::unique_lock<std::mutex> locker(task_mutex);
+            status = STOP;
+        }
         task_cond.notify_all();
         for (auto& i : threads) {
             if (i.thread->joinable()) {


### PR DESCRIPTION
原子谓词也可能导致唤醒问题
参考:
1. https://www.modernescpp.com/index.php/c-core-guidelines-be-aware-of-the-traps-of-condition-variables/
2. https://www.cnblogs.com/fenghualong/p/13855360.html