### PR TITLE
Prevent race condition when detaching sockets

### DIFF
--- a/event/hevent.h
+++ b/event/hevent.h
@@ -291,5 +291,13 @@ void hio_memmove_readbuf(hio_t* io);
         EVENT_ACTIVE(ev);\
         ev->pending = 0;\
     } while(0)
+    
+#define EVENT_UNPENDING(ev) \
+    do {\
+        if (ev->pending) {\
+            ev->pending = 0;\
+            ev->loop->npendings--;\
+        }\
+    } while(0)
 
 #endif // HV_EVENT_H_

--- a/event/hloop.c
+++ b/event/hloop.c
@@ -117,7 +117,7 @@ static int hloop_process_pendings(hloop_t* loop) {
         cur = loop->pendings[i];
         while (cur) {
             next = cur->pending_next;
-            if (cur->pending) {
+            if (cur->pending && cur->loop == loop) {
                 if (cur->active && cur->cb) {
                     cur->cb(cur);
                     ++ncbs;
@@ -875,6 +875,7 @@ int hio_del(hio_t* io, int events) {
         io->loop->nios--;
         // NOTE: not EVENT_DEL, avoid free
         EVENT_INACTIVE(io);
+        EVENT_UNPENDING(io);
     }
     return 0;
 }


### PR DESCRIPTION
This PR addresses [issue #754](https://github.com/ithewei/libhv/issues/754) — a rare race condition involving multithreading and socket reuse when using `hio_detach` / `hio_attach`.

> Note: The patch was implemented by @ithewei based on the issue I reported. I'm submitting this PR just to help close the loop and track the fix properly.

Thanks again for the fix and for maintaining the project!