### PR TITLE
fix: log crashes when max_bufsize is exceeded

### DIFF
--- a/base/hlog.c
+++ b/base/hlog.c
@@ -463,6 +463,7 @@ int logger_print(logger_t* logger, int level, const char* fmt, ...) {
                 buf[len++] = *p;
             }
             ++p;
+            if (len >= bufsize) break;
         }
     } else {
         len += snprintf(buf + len, bufsize - len, "%04d-%02d-%02d %02d:%02d:%02d.%03d %s ",
@@ -475,12 +476,15 @@ int logger_print(logger_t* logger, int level, const char* fmt, ...) {
         va_end(ap);
     }
 
-    if (logger->enable_color) {
+    if (logger->enable_color && len < bufsize) {
         len += snprintf(buf + len, bufsize - len, "%s", CLR_CLR);
     }
 
-    if(len < bufsize) {
+    if (len < bufsize) {
         buf[len++] = '\n';
+    } else {
+        buf[bufsize - 1] = '\n';
+        len = bufsize;
     }
 
     if (logger->handler) {


### PR DESCRIPTION
打印HTTP请求响应时意外遇到HTML超长错误数据超出MAX_BUFSIZE日志崩溃，每次需要注意验证打印的LOG不能大于MAX_BUFSIZE很繁琐。
其他人也遇到过类似的情况：https://github.com/ithewei/libhv/issues/730