### PR TITLE
fix: atexit destroy default logger multithreading env bug

### DIFF
--- a/base/hlog.c
+++ b/base/hlog.c
@@ -499,10 +499,13 @@ int logger_print(logger_t* logger, int level, const char* fmt, ...) {
 }
 
 static logger_t* s_logger = NULL;
+void default_logger_exit_fsync(void) {
+    if (s_logger) logger_fsync(s_logger);
+}
 logger_t* hv_default_logger() {
     if (s_logger == NULL) {
         s_logger = logger_create();
-        atexit(hv_destroy_default_logger);
+        atexit(default_logger_exit_fsync);
     }
     return s_logger;
 }


### PR DESCRIPTION
遇到HttpServer loop_thread 中的日志 EventLoop started消息 和 EventLoop stopped消息 日志文件意外分离，经过排查发现原因如下
hlog_set_file或hlog_set_xxxx各种设置后，在httpserver多线程或自己的业务线程运行时，外部执行 -s stop 或 -s restart 触发 signal_handler 或其他形式的原因只要调用 exit 就会触发 atexit 的 hv_destroy_default_logger销毁，此时其他工作线程使用的logger被重置导致开头的hlog_set_各类设置失效。

我发现其他人也遇到过类似现象 https://github.com/ithewei/libhv/issues/171