### PR TITLE
add rcv_bufsize on kcp_setting to allow recv larger package

### DIFF
--- a/event/hloop.h
+++ b/event/hloop.h
@@ -696,6 +696,8 @@ typedef struct kcp_setting_s {
     int mtu;
     // ikcp_update
     int update_interval;
+    // bufsize for ikcp_recv
+    size_t rcv_bufsize;
 
 #ifdef __cplusplus
     kcp_setting_s() {
@@ -715,6 +717,7 @@ typedef struct kcp_setting_s {
         rcvwnd = 0;
         mtu = 1400;
         update_interval = 10; // ms
+        rcv_bufsize = 0;
     }
 #endif
 } kcp_setting_t;

--- a/event/kcp/hkcp.c
+++ b/event/kcp/hkcp.c
@@ -72,7 +72,11 @@ kcp_t* hio_get_kcp(hio_t* io, uint32_t conv, struct sockaddr* addr) {
         kcp->update_timer = htimer_add(io->loop, __kcp_update_timer_cb, update_interval, INFINITE);
         kcp->update_timer->privdata = rudp;
     }
-    // NOTE: alloc kcp->readbuf when hio_read_kcp
+    // NOTE: alloc kcp->readbuf now, otherwise hio_read_kcp will use default size (DEFAULT_KCP_READ_BUFSIZE)
+    if (setting->rcv_bufsize > 0) {
+        kcp->readbuf.len = setting->rcv_bufsize;
+        HV_ALLOC(kcp->readbuf.base, kcp->readbuf.len);
+    }
     return kcp;
 }
 


### PR DESCRIPTION
I add a member to kcp_setting_t so that it can allow recv larger package in kcp session.
I wonder whether it's reasonable or not, or larger package will rersult in some performace matter(maybe that's why it's not supported before)?