### PR TITLE
feat: auto-drop KCP packets on readbuf overflow

### DIFF
--- a/event/kcp/hkcp.c
+++ b/event/kcp/hkcp.c
@@ -141,6 +141,11 @@ int hio_read_kcp (hio_t* io, void* buf, int readbytes) {
     while (1) {
         int nrecv = ikcp_recv(kcp->ikcp, kcp->readbuf.base, kcp->readbuf.len);
         // printf("ikcp_recv nrecv=%d\n", nrecv);
+        if (nrecv == -3) { // drop packet when larger than readbuf.len
+            int peeksize = ikcp_peeksize(kcp->ikcp);
+            ikcp_recv(kcp->ikcp, NULL, peeksize);
+            nrecv = 0;
+        }
         if (nrecv < 0) break;
         hio_read_cb(io, kcp->readbuf.base, nrecv);
         ret += nrecv;


### PR DESCRIPTION
I found kcp service will get unavailable when large packet comes, so I think it's neccessary to drop it so that the next packet can be handled, and service keep on going.