### PR TITLE
Add uploadLargeFormFile() for memory-efficient multipart uploads

### DIFF
--- a/http/client/requests.h
+++ b/http/client/requests.h
@@ -119,6 +119,32 @@ HV_INLINE Response uploadFormFile(const char* url, const char* name, const char*
 #endif
 
 typedef std::function<void(size_t sended_bytes, size_t total_bytes)>    upload_progress_cb;
+
+// Internal helper for streaming file data through an established connection
+// Used by uploadLargeFile() and uploadLargeFormFile()
+namespace internal {
+HV_INLINE int streamFileToConnection(
+    hv::HttpClient& cli,
+    HFile& file,
+    size_t file_size,
+    upload_progress_cb progress_cb = NULL)
+{
+    size_t sent_bytes = 0;
+    char buf[40960]; // 40K
+    while (sent_bytes < file_size) {
+        size_t to_read = file_size - sent_bytes;
+        if (to_read > sizeof(buf)) to_read = sizeof(buf);
+        int nread = file.read(buf, to_read);
+        if (nread <= 0) return -1;
+        int nsend = cli.sendData(buf, nread);
+        if (nsend != nread) return -1;
+        sent_bytes += nsend;
+        if (progress_cb) progress_cb(sent_bytes, file_size);
+    }
+    return 0;
+}
+} // namespace internal
+
 HV_INLINE Response uploadLargeFile(const char* url, const char* filepath, upload_progress_cb progress_cb = NULL, http_method method = HTTP_POST, const http_headers& headers = DefaultHeaders) {
     // open file
     HFile file;
@@ -151,24 +177,9 @@ HV_INLINE Response uploadLargeFile(const char* url, const char* filepath, upload
         return NULL;
     }
 
-    // send file
-    size_t sended_bytes = 0;
-    char filebuf[40960]; // 40K
-    int filebuflen = sizeof(filebuf);
-    int nread = 0, nsend = 0;
-    while (sended_bytes < total_bytes) {
-        nread = file.read(filebuf, filebuflen);
-        if (nread <= 0) {
-            return NULL;
-        }
-        nsend = cli.sendData(filebuf, nread);
-        if (nsend != nread) {
-            return NULL;
-        }
-        sended_bytes += nsend;
-        if (progress_cb) {
-            progress_cb(sended_bytes, total_bytes);
-        }
+    // stream file using shared helper
+    if (internal::streamFileToConnection(cli, file, total_bytes, progress_cb) != 0) {
+        return NULL;
     }
 
     // recv response
@@ -179,6 +190,85 @@ HV_INLINE Response uploadLargeFile(const char* url, const char* filepath, upload
     }
     return resp;
 }
+
+// Streaming multipart form file upload - memory efficient for large files
+// Overload with explicit upload_filename for when the filename differs from local path
+#ifndef WITHOUT_HTTP_CONTENT
+HV_INLINE Response uploadLargeFormFile(const char* url, const char* name, const char* filepath,
+    const char* upload_filename,
+    std::map<std::string, std::string>& params = hv::empty_map,
+    upload_progress_cb progress_cb = NULL, http_method method = HTTP_POST,
+    const http_headers& headers = DefaultHeaders)
+{
+    HFile file;
+    if (file.open(filepath, "rb") != 0) return NULL;
+
+    size_t file_size = file.size(filepath);
+    const char* filename = upload_filename ? upload_filename : hv_basename(filepath);
+    static const char* BOUNDARY = "----libhvFormBoundary7MA4YWxkTrZu0gW";
+
+    // Build preamble (form fields + file header)
+    std::string preamble;
+    for (auto& param : params) {
+        preamble += "--"; preamble += BOUNDARY; preamble += "\r\n";
+        preamble += "Content-Disposition: form-data; name=\"";
+        preamble += param.first; preamble += "\"\r\n\r\n";
+        preamble += param.second; preamble += "\r\n";
+    }
+    preamble += "--"; preamble += BOUNDARY; preamble += "\r\n";
+    preamble += "Content-Disposition: form-data; name=\"";
+    preamble += name; preamble += "\"; filename=\"";
+    preamble += filename; preamble += "\"\r\n";
+    preamble += "Content-Type: application/octet-stream\r\n\r\n";
+
+    std::string epilogue = "\r\n--";
+    epilogue += BOUNDARY; epilogue += "--\r\n";
+
+    // Total = preamble + file + epilogue
+    size_t total_length = preamble.size() + file_size + epilogue.size();
+
+    hv::HttpClient cli;
+    auto req = std::make_shared<HttpRequest>();
+    req->method = method;
+    req->url = url;
+    req->timeout = 3600;
+    req->SetHeader("Content-Type", std::string("multipart/form-data; boundary=") + BOUNDARY);
+    req->SetHeader("Content-Length", hv::to_string(total_length));
+    if (&headers != &DefaultHeaders) {
+        for (auto& h : headers) req->SetHeader(h.first.c_str(), h.second);
+    }
+
+    req->ParseUrl();
+    if (cli.connect(req->host.c_str(), req->port, req->IsHttps(), req->connect_timeout) < 0) {
+        return NULL;
+    }
+    if (cli.sendHeader(req.get()) != 0) return NULL;
+
+    // Send preamble
+    if (cli.sendData(preamble.data(), preamble.size()) != (int)preamble.size()) return NULL;
+
+    // Stream file using shared helper
+    if (internal::streamFileToConnection(cli, file, file_size, progress_cb) != 0) {
+        return NULL;
+    }
+
+    // Send epilogue
+    if (cli.sendData(epilogue.data(), epilogue.size()) != (int)epilogue.size()) return NULL;
+
+    auto resp = std::make_shared<HttpResponse>();
+    if (cli.recvResponse(resp.get()) != 0) return NULL;
+    return resp;
+}
+
+// Convenience overload - uses basename of filepath as upload filename
+HV_INLINE Response uploadLargeFormFile(const char* url, const char* name, const char* filepath,
+    std::map<std::string, std::string>& params = hv::empty_map,
+    upload_progress_cb progress_cb = NULL, http_method method = HTTP_POST,
+    const http_headers& headers = DefaultHeaders)
+{
+    return uploadLargeFormFile(url, name, filepath, NULL, params, progress_cb, method, headers);
+}
+#endif
 
 // see examples/wget.cpp
 typedef std::function<void(size_t received_bytes, size_t total_bytes)> download_progress_cb;


### PR DESCRIPTION
## The problem

`uploadFormFile()` loads the whole file into memory before sending. That's fine for small files, but when you're uploading 50-100MB files on an embedded device with 512MB RAM... yeah, not great.

I hit this while building a 3D printer touchscreen UI. Uploading large G-code files was causing the whole system to choke.

## What this adds

New function `uploadLargeFormFile()` - like `uploadFormFile()` but streams the file in chunks (same pattern as `uploadLargeFile()` vs `uploadFile()`).

```cpp
// Basic usage (filename derived from path)
auto resp = requests::uploadLargeFormFile(
    "http://server/upload",
    "file",                    // form field name
    "/path/to/huge_file.bin",
    params,                    // extra form fields
    [](size_t sent, size_t total) {
        printf("%.1f%%\n", 100.0 * sent / total);
    }
);

// With custom upload filename (when local path differs from desired name)
auto resp = requests::uploadLargeFormFile(
    "http://server/upload",
    "file",
    "/tmp/modified_version.bin",
    "original_name.bin",       // upload filename override
    params,
    progress_cb
);
```

Memory usage for a 100MB file:
- `uploadFormFile()`: ~100MB
- `uploadLargeFormFile()`: ~40KB (just the chunk buffer)

## Implementation

I extracted a shared helper to avoid duplicating the streaming loop from `uploadLargeFile()`:

- **New**: `internal::streamFileToConnection()` helper - extracted from `uploadLargeFile()`
- **Refactor**: `uploadLargeFile()` now uses the shared helper (same behavior, no breaking change)
- **New**: `uploadLargeFormFile()` for multipart uploads, also uses the shared helper

No breaking changes - existing code works exactly as before.