### PR TITLE
feat: Re-query the DNS during reconnection

### DIFF
--- a/evpp/TcpClient.h
+++ b/evpp/TcpClient.h
@@ -105,6 +105,14 @@ public:
 
     int startConnect() {
         if (channel == NULL || channel->isClosed()) {
+            // Re-resolve DNS to get the latest IP address
+            memset(&remote_addr, 0, sizeof(remote_addr));
+            int ret = sockaddr_set_ipport(&remote_addr, remote_host.c_str(), remote_port);
+            if (ret != 0) {
+                hloge("sockaddr_set_ipport %s:%d failed!\n", remote_host.c_str(), remote_port);
+                return ret;
+            }
+            
             int connfd = createsocket(&remote_addr.sa);
             if (connfd < 0) {
                 hloge("createsocket %s:%d return %d!\n", remote_host.c_str(), remote_port, connfd);


### PR DESCRIPTION
中文：
在 WebSocket 长连接场景中此功能尤为重要。
启用 reconn_setting_t 重连接功能后，客户端在重新建立连接时会再次进行 DNS 查询，以获取最新的 IP 地址，从而避免因 DNS 切换导致无法连接服务的问题。该机制通常用于同一域名下主从 IP 切换的重连场景：先完成 DNS 切换，再停止旧服务，使连接在重连时能够成功接入新的服务节点。

English:
This mechanism is especially critical for WebSocket long-lived connections and is strongly recommended to be enabled.
When the reconn_setting_t reconnection feature is enabled, the client performs a DNS lookup again during reconnection to obtain the latest IP address. This prevents connection failures caused by DNS changes. This mechanism is commonly used in reconnection scenarios involving primary/secondary IP switching under the same domain name: the DNS is switched first, then the old service is stopped, allowing the reconnection to successfully connect to the new service node.