### PR TITLE
fix thread unsafe call to localtime on linux

### DIFF
--- a/base/hlog.c
+++ b/base/hlog.c
@@ -378,7 +378,8 @@ int logger_print(logger_t* logger, int level, const char* fmt, ...) {
     struct tm* tm = NULL;
     gettimeofday(&tv, NULL);
     time_t tt = tv.tv_sec;
-    tm = localtime(&tt);
+    struct tm tm_buf;
+    tm = localtime_r(&tt, &tm_buf);
     year     = tm->tm_year + 1900;
     month    = tm->tm_mon  + 1;
     day      = tm->tm_mday;


### PR DESCRIPTION
On Windows GetLocalTime is thread-safe. On linux localtime_r is thread-safe, while localtime not. This commit replaces usage of localtime in places not under mutex (only one such place) to localtime_r.

This bug was detected in daScript CI:
https://github.com/GaijinEntertainment/daScript/actions/runs/25911600620/job/76157878377?pr=2668