### PR TITLE
Add multicast helper function

### DIFF
--- a/base/hsocket.h
+++ b/base/hsocket.h
@@ -283,6 +283,58 @@ HV_INLINE int so_linger(int sockfd, int timeout DEFAULT(1)) {
 #endif
 }
 
+HV_INLINE int udp_multicast_loop(int sockfd, int value DEFAULT(1))
+{
+    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_LOOP, (void *)&value, sizeof(int));
+}
+HV_INLINE int udp_multicast_loop6(int sockfd, int value DEFAULT(1))
+{
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, (void *)&value, sizeof(int));
+}
+
+HV_INLINE int udp_multicast_ttl(int sockfd, int value)
+{
+    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_TTL, (void *)&value, sizeof(int));
+}
+HV_INLINE int udp_multicast_ttl6(int sockfd, int value)
+{
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (void *)&value, sizeof(int));
+}
+
+HV_INLINE int udp_joingroup(int sockfd, const char* group_ip, const char* intf_ip DEFAULT(ANYADDR))
+{
+    struct ip_mreq mreq;
+    inet_pton(AF_INET, group_ip, &mreq.imr_multiaddr);
+    inet_pton(AF_INET, intf_ip,  &mreq.imr_interface);
+    return setsockopt(sockfd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (void *)&mreq, sizeof(mreq));
+}
+
+HV_INLINE int udp_leavegroup(int sockfd, const char* group_ip, const char* intf_ip DEFAULT(ANYADDR))
+{
+    struct ip_mreq mreq;
+    inet_pton(AF_INET, group_ip, &mreq.imr_multiaddr);
+    inet_pton(AF_INET, intf_ip,  &mreq.imr_interface);
+    return setsockopt(sockfd, IPPROTO_IP, IP_DROP_MEMBERSHIP, (void *)&mreq, sizeof(mreq));
+}
+
+// intf_idx 填写字符串整数 为了和ipv4保持一致
+HV_INLINE int udp_joingroup6(int sockfd, const char* group_ip, const char* intf_idx DEFAULT("0"))
+{
+    struct ipv6_mreq mreq;
+    inet_pton(AF_INET6, group_ip, &mreq.ipv6mr_multiaddr);
+    mreq.ipv6mr_interface = atoi(intf_idx);
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, (void *)&mreq, sizeof(mreq));
+}
+
+HV_INLINE int udp_leavegroup6(int sockfd, const char* group_ip, const char* intf_idx DEFAULT("0"))
+{
+    struct ipv6_mreq mreq;
+    inet_pton(AF_INET6, group_ip, &mreq.ipv6mr_multiaddr);
+    mreq.ipv6mr_interface = atoi(intf_idx);
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP, (void *)&mreq, sizeof(mreq));
+}
+
+
 END_EXTERN_C
 
 #endif // HV_SOCKET_H_

--- a/base/hsocket.h
+++ b/base/hsocket.h
@@ -285,20 +285,20 @@ HV_INLINE int so_linger(int sockfd, int timeout DEFAULT(1)) {
 
 HV_INLINE int udp_multicast_loop(int sockfd, int value DEFAULT(1))
 {
-    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_LOOP, (void *)&value, sizeof(int));
+    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_LOOP, (const char*)&value, sizeof(int));
 }
 HV_INLINE int udp_multicast_loop6(int sockfd, int value DEFAULT(1))
 {
-    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, (void *)&value, sizeof(int));
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, (const char*)&value, sizeof(int));
 }
 
 HV_INLINE int udp_multicast_ttl(int sockfd, int value)
 {
-    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_TTL, (void *)&value, sizeof(int));
+    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_TTL, (const char*)&value, sizeof(int));
 }
 HV_INLINE int udp_multicast_ttl6(int sockfd, int value)
 {
-    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (void *)&value, sizeof(int));
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (const char*)&value, sizeof(int));
 }
 
 HV_INLINE int udp_joingroup(int sockfd, const char* group_ip, const char* intf_ip DEFAULT(ANYADDR))
@@ -306,7 +306,7 @@ HV_INLINE int udp_joingroup(int sockfd, const char* group_ip, const char* intf_i
     struct ip_mreq mreq;
     inet_pton(AF_INET, group_ip, &mreq.imr_multiaddr);
     inet_pton(AF_INET, intf_ip,  &mreq.imr_interface);
-    return setsockopt(sockfd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (void *)&mreq, sizeof(mreq));
+    return setsockopt(sockfd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
 }
 
 HV_INLINE int udp_leavegroup(int sockfd, const char* group_ip, const char* intf_ip DEFAULT(ANYADDR))
@@ -314,7 +314,7 @@ HV_INLINE int udp_leavegroup(int sockfd, const char* group_ip, const char* intf_
     struct ip_mreq mreq;
     inet_pton(AF_INET, group_ip, &mreq.imr_multiaddr);
     inet_pton(AF_INET, intf_ip,  &mreq.imr_interface);
-    return setsockopt(sockfd, IPPROTO_IP, IP_DROP_MEMBERSHIP, (void *)&mreq, sizeof(mreq));
+    return setsockopt(sockfd, IPPROTO_IP, IP_DROP_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
 }
 
 // intf_idx 填写字符串整数 为了和ipv4保持一致
@@ -323,7 +323,7 @@ HV_INLINE int udp_joingroup6(int sockfd, const char* group_ip, const char* intf_
     struct ipv6_mreq mreq;
     inet_pton(AF_INET6, group_ip, &mreq.ipv6mr_multiaddr);
     mreq.ipv6mr_interface = atoi(intf_idx);
-    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, (void *)&mreq, sizeof(mreq));
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
 }
 
 HV_INLINE int udp_leavegroup6(int sockfd, const char* group_ip, const char* intf_idx DEFAULT("0"))
@@ -331,7 +331,7 @@ HV_INLINE int udp_leavegroup6(int sockfd, const char* group_ip, const char* intf
     struct ipv6_mreq mreq;
     inet_pton(AF_INET6, group_ip, &mreq.ipv6mr_multiaddr);
     mreq.ipv6mr_interface = atoi(intf_idx);
-    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP, (void *)&mreq, sizeof(mreq));
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
 }
 
 


### PR DESCRIPTION
添加了一些组播常用的函数，原本想把ipv4和ipv6的函数统一成一个，但是没找到简单判断sockfd的ip版本的办法，参数改成hio_t，的话会与其他函数不一致