### PR TITLE
fix: register MqttClient::subscribe ack callback regardless of QoS value

### DIFF
--- a/mqtt/mqtt_client.h
+++ b/mqtt/mqtt_client.h
@@ -250,7 +250,7 @@ public:
 
     int subscribe(const char* topic, int qos = 0, MqttCallback ack_cb = NULL) {
         int mid = mqtt_client_subscribe(client, topic, qos);
-        if (qos > 0 && mid >= 0 && ack_cb) {
+        if (mid >= 0 && ack_cb) {
             setAckCallback(mid, ack_cb);
         }
         return mid;


### PR DESCRIPTION
注册订阅回调与topic的qos无关