### PR TITLE
fix(http2): large-body framing, async-handler responses, client ALPN

### DIFF
--- a/examples/curl.cpp
+++ b/examples/curl.cpp
@@ -271,7 +271,9 @@ int main(int argc, char* argv[]) {
             }
         } else if (state == HP_BODY) {
             if (data && size) {
-                printf("%.*s", (int)size, data);
+                // write raw bytes (body may be binary, e.g. an image, so it can
+                // contain NUL -- printf("%s") would truncate at the first NUL).
+                fwrite(data, 1, size, stdout);
                 // This program no need to save data to body.
                 // res->body.append(data, size);
             }

--- a/examples/httpd/handler.cpp
+++ b/examples/httpd/handler.cpp
@@ -154,10 +154,15 @@ int Handler::grpc(HttpRequest* req, HttpResponse* resp) {
     }
     // parse protobuf
     // ParseFromString(req->body);
-    // resp->content_type = APPLICATION_GRPC;
+    resp->content_type = APPLICATION_GRPC;
     // serailize protobuf
     // resp->body = SerializeAsString(xxx);
-    response_status(resp, 0, "OK");
+    // gRPC carries the RPC result in the trailing grpc-status (0 = OK); the
+    // HTTP :status stays 200. To report an error, set grpc-status (see the
+    // GRPC_STATUS_* codes in base/herr.h) and optionally grpc-message:
+    //   resp->headers["grpc-status"]  = "5";               // NOT_FOUND
+    //   resp->headers["grpc-message"] = "user not found";  // optional, ASCII
+    resp->headers["grpc-status"] = "0";
     return 200;
 }
 

--- a/http/Http2Parser.cpp
+++ b/http/Http2Parser.cpp
@@ -205,13 +205,19 @@ void Http2Parser::prepareSendBody() {
     send_off = 0;
     const char* content = (const char*)submited->Content();
     size_t content_length = submited->ContentLength();
-    if (is_grpc && content_length > 0) {
+    if (is_grpc) {
+        // gRPC always carries a length-prefixed message, even for an empty
+        // payload (e.g. google.protobuf.Empty). Emitting the 5-byte header also
+        // keeps send_len > 0 so a data_provider is attached and the stream stays
+        // open for the grpc-status trailer.
         grpc_message_hd msghd;
         msghd.flags = 0;
         msghd.length = (unsigned int)content_length;
         send_body.resize(GRPC_MESSAGE_HDLEN + content_length);
         grpc_message_hd_pack(&msghd, (unsigned char*)&send_body[0]);
-        memcpy(&send_body[GRPC_MESSAGE_HDLEN], content, content_length);
+        if (content_length > 0) {
+            memcpy(&send_body[GRPC_MESSAGE_HDLEN], content, content_length);
+        }
         send_buf = send_body.data();
         send_len = send_body.size();
     } else {

--- a/http/Http2Parser.cpp
+++ b/http/Http2Parser.cpp
@@ -2,6 +2,9 @@
 
 #include "Http2Parser.h"
 
+#include <list>
+#include <mutex>
+
 static nghttp2_nv make_nv(const char* name, const char* value) {
     nghttp2_nv nv;
     nv.name = (uint8_t*)name;
@@ -36,42 +39,58 @@ static int on_data_chunk_recv_callback(nghttp2_session *session,
         size_t len, void *userdata);
 static int on_frame_recv_callback(nghttp2_session *session,
         const nghttp2_frame *frame, void *userdata);
-/*
+
+// data_provider read callback: copy the outgoing body to nghttp2, which does
+// the DATA framing, splitting to SETTINGS_MAX_FRAME_SIZE and flow control.
+// (One copy into nghttp2's buffer; the safe/simple path vs. NO_COPY framing.)
+// For gRPC, send_body holds the 5-byte-length-prefixed payload.
 static ssize_t data_source_read_callback(nghttp2_session *session,
         int32_t stream_id, uint8_t *buf, size_t length,
-        uint32_t *data_flags, nghttp2_data_source *source, void *userdata);
-*/
+        uint32_t *data_flags, nghttp2_data_source *source, void *userdata) {
+    Http2Parser* hp = (Http2Parser*)userdata;
+    size_t remain = hp->send_len - hp->send_off;
+    size_t n = remain < length ? remain : length;
+    if (n > 0) {
+        memcpy(buf, hp->send_buf + hp->send_off, n);
+        hp->send_off += n;
+    }
+    if (hp->send_off >= hp->send_len) {
+        *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+        // gRPC carries the status in trailing HEADERS, so keep the stream open
+        // for the trailer; otherwise nghttp2 sets END_STREAM here.
+        if (hp->is_grpc && hp->type == HTTP_SERVER) {
+            *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+        }
+    }
+    return (ssize_t)n;
+}
 
 
 Http2Parser::Http2Parser(http_session_type type) {
-    if (cbs == NULL) {
-        nghttp2_session_callbacks_new(&cbs);
-        nghttp2_session_callbacks_set_on_header_callback(cbs, on_header_callback);
-        nghttp2_session_callbacks_set_on_data_chunk_recv_callback(cbs, on_data_chunk_recv_callback);
-        nghttp2_session_callbacks_set_on_frame_recv_callback(cbs, on_frame_recv_callback);
-    }
+    this->type = type;
+    initCallbacks();
     if (type == HTTP_CLIENT) {
         nghttp2_session_client_new(&session, cbs, this);
-        state = H2_SEND_MAGIC;
     }
     else if (type == HTTP_SERVER) {
         nghttp2_session_server_new(&session, cbs, this);
-        state = H2_WANT_RECV;
     }
-    //nghttp2_session_set_user_data(session, this);
+    state = H2_WANT_RECV;
     submited = NULL;
     parsed = NULL;
+    error = 0;
     stream_id = -1;
     stream_closed = 0;
+    frame_type_when_stream_closed = 0;
+    send_buf = NULL;
+    send_len = 0;
+    send_off = 0;
+    is_grpc = false;
 
     nghttp2_settings_entry settings[] = {
         {NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 100}
     };
     nghttp2_submit_settings(session, NGHTTP2_FLAG_NONE, settings, ARRAY_SIZE(settings));
-    state = H2_SEND_SETTINGS;
-
-    //nghttp2_submit_ping(session, NGHTTP2_FLAG_NONE, NULL);
-    //state = H2_SEND_PING;
 }
 
 Http2Parser::~Http2Parser() {
@@ -82,101 +101,31 @@ Http2Parser::~Http2Parser() {
 }
 
 int Http2Parser::GetSendData(char** data, size_t* len) {
-    // HTTP2_MAGIC,HTTP2_SETTINGS,HTTP2_HEADERS
-    *len = nghttp2_session_mem_send(session, (const uint8_t**)data);
-    printd("nghttp2_session_mem_send %d\n", *len);
-    if (*len != 0) return *len;
-
-    if (submited == NULL) return 0;
-    // HTTP2_DATA
-    if (state == H2_SEND_HEADERS) {
-        void* content = submited->Content();
-        int content_length = submited->ContentLength();
-        // HTTP2 DATA framehd
-        state = H2_SEND_DATA_FRAME_HD;
-        http2_frame_hd  framehd;
-        framehd.length = content_length;
-        framehd.type = HTTP2_DATA;
-        framehd.flags = HTTP2_FLAG_END_STREAM;
-        framehd.stream_id = stream_id;
-        *data = (char*)frame_hdbuf;
-        *len = HTTP2_FRAME_HDLEN;
-        printd("HTTP2 SEND_DATA_FRAME_HD...\n");
-        if (submited->ContentType() == APPLICATION_GRPC) {
-            grpc_message_hd msghd;
-            msghd.flags = 0;
-            msghd.length = content_length;
-            printd("grpc_message_hd: flags=%d length=%d\n", msghd.flags, msghd.length);
-
-            if (type == HTTP_SERVER) {
-                // grpc server send grpc-status in HTTP2 header frame
-                framehd.flags = HTTP2_FLAG_NONE;
-
-                /*
-                // @test protobuf
-                // message StringMessage {
-                //     string str = 1;
-                // }
-                int protobuf_taglen = 0;
-                int tag = PROTOBUF_MAKE_TAG(1, WIRE_TYPE_LENGTH_DELIMITED);
-                unsigned char* p = frame_hdbuf + HTTP2_FRAME_HDLEN + GRPC_MESSAGE_HDLEN;
-                int bytes = varint_encode(tag, p);
-                protobuf_taglen += bytes;
-                p += bytes;
-                bytes = varint_encode(content_length, p);
-                protobuf_taglen += bytes;
-                msghd.length += protobuf_taglen;
-                framehd.length += protobuf_taglen;
-                *len += protobuf_taglen;
-                */
-            }
-
-            grpc_message_hd_pack(&msghd, frame_hdbuf + HTTP2_FRAME_HDLEN);
-            framehd.length += GRPC_MESSAGE_HDLEN;
-            *len += GRPC_MESSAGE_HDLEN;
-        }
-        http2_frame_hd_pack(&framehd, frame_hdbuf);
+    // nghttp2 produces everything: magic, SETTINGS, HEADERS, DATA (framed and
+    // flow-controlled via the data_provider), SETTINGS/PING ACK, WINDOW_UPDATE,
+    // trailers. Just drain it.
+    ssize_t ret = nghttp2_session_mem_send(session, (const uint8_t**)data);
+    if (ret < 0) {
+        error = (int)ret;
+        *len = 0;
+        return 0;
     }
-    else if (state == H2_SEND_DATA_FRAME_HD) {
-        // HTTP2 DATA
-        void* content = submited->Content();
-        int content_length = submited->ContentLength();
-        if (content_length == 0) {
-            // skip send_data
-            goto send_done;
-        }
-        else {
-            printd("HTTP2 SEND_DATA... content_length=%d\n", content_length);
-            state = H2_SEND_DATA;
-            *data = (char*)content;
-            *len = content_length;
-        }
-    }
-    else if (state == H2_SEND_DATA) {
-send_done:
-        state = H2_SEND_DONE;
-        if (submited->ContentType() == APPLICATION_GRPC) {
-            if (type == HTTP_SERVER && stream_closed) {
-                // grpc HEADERS grpc-status
-                printd("grpc HEADERS grpc-status: 0\n");
-                int flags = NGHTTP2_FLAG_END_STREAM | NGHTTP2_FLAG_END_HEADERS;
-                nghttp2_nv nv = make_nv("grpc-status", "0");
-                nghttp2_submit_headers(session, flags, stream_id, NULL, &nv, 1, NULL);
-                *len = nghttp2_session_mem_send(session, (const uint8_t**)data);
-            }
-        }
-    }
-
-    printd("GetSendData %d\n", *len);
-    return *len;
+    *len = (size_t)ret;
+    printd("nghttp2_session_mem_send %zu\n", *len);
+    return (int)*len;
 }
 
 int Http2Parser::FeedRecvData(const char* data, size_t len) {
-    printd("nghttp2_session_mem_recv %d\n", len);
+    printd("nghttp2_session_mem_recv %zu\n", len);
     state = H2_WANT_RECV;
-    size_t ret = nghttp2_session_mem_recv(session, (const uint8_t*)data, len);
-    if (ret != len) {
-        error = ret;
+    ssize_t ret = nghttp2_session_mem_recv(session, (const uint8_t*)data, len);
+    if (ret < 0) {
+        // nghttp2 error (e.g. NGHTTP2_ERR_*): surface it, caller closes.
+        error = (int)ret;
+        return (int)ret;
+    }
+    if ((size_t)ret != len) {
+        error = (int)ret;
     }
     return (int)ret;
 }
@@ -209,35 +158,66 @@ int Http2Parser::SubmitRequest(HttpRequest* req) {
         snprintf(c_str, sizeof(c_str), "%s:%d", req->host.c_str(), req->port);
         nvs.push_back(make_nv(":authority", c_str));
     }
-    const char* name;
     const char* value;
+    // HTTP/2 requires lowercase field names. Build lowercased copies rather
+    // than mutating the caller's map keys in place (which is UB and a surprise
+    // side effect). std::list keeps element addresses stable for make_nv2.
+    std::list<std::string> lower_names;
     for (auto& header : req->headers) {
-        name = header.first.c_str();
+        lower_names.push_back(header.first);
+        std::string& name = lower_names.back();
+        hv_strlower(&name[0]);
         value = header.second.c_str();
-        hv_strlower((char*)name);
-        if (strcmp(name, "host") == 0) {
+        if (name == "host") {
             // :authority
             continue;
         }
-        if (strcmp(name, "connection") == 0) {
+        if (name == "connection") {
             // HTTP2 default keep-alive
             continue;
         }
-        if (strcmp(name, "content-length") == 0) {
+        if (name == "content-length") {
             // HTTP2 have frame_hd.length
             continue;
         }
-        nvs.push_back(make_nv2(name, value, header.first.size(), header.second.size()));
+        nvs.push_back(make_nv2(name.c_str(), value, name.size(), header.second.size()));
     }
-    int flags = NGHTTP2_FLAG_END_HEADERS;
-    // we set EOS on DATA frame
-    stream_id = nghttp2_submit_headers(session, flags, -1, NULL, &nvs[0], nvs.size(), NULL);
-    // avoid DATA_SOURCE_COPY, we do not use nghttp2_submit_data
-    // nghttp2_data_provider data_prd;
-    // data_prd.read_callback = data_source_read_callback;
-    //stream_id = nghttp2_submit_request(session, NULL, &nvs[0], nvs.size(), &data_prd, NULL);
-    state = H2_SEND_HEADERS;
+    // Set up the outgoing body as an nghttp2 data_provider so nghttp2 handles
+    // DATA framing, frame splitting and flow control. For gRPC, prepend the
+    // 5-byte length-prefix into an owned buffer.
+    is_grpc = (req->ContentType() == APPLICATION_GRPC);
+    prepareSendBody();
+    nghttp2_data_provider data_prd;
+    data_prd.source.ptr = this;
+    data_prd.read_callback = data_source_read_callback;
+    stream_id = nghttp2_submit_request(session, NULL, &nvs[0], nvs.size(),
+                                       send_len > 0 ? &data_prd : NULL, NULL);
+    if (stream_id < 0) {
+        error = stream_id;
+        return -1;
+    }
     return 0;
+}
+
+// Stage submited->Content() into the send cursor; for gRPC prepend the
+// length-prefixed message header into an owned buffer (send_body).
+void Http2Parser::prepareSendBody() {
+    send_off = 0;
+    const char* content = (const char*)submited->Content();
+    size_t content_length = submited->ContentLength();
+    if (is_grpc && content_length > 0) {
+        grpc_message_hd msghd;
+        msghd.flags = 0;
+        msghd.length = (unsigned int)content_length;
+        send_body.resize(GRPC_MESSAGE_HDLEN + content_length);
+        grpc_message_hd_pack(&msghd, (unsigned char*)&send_body[0]);
+        memcpy(&send_body[GRPC_MESSAGE_HDLEN], content, content_length);
+        send_buf = send_body.data();
+        send_len = send_body.size();
+    } else {
+        send_buf = content;
+        send_len = content_length;
+    }
 }
 
 int Http2Parser::SubmitResponse(HttpResponse* res) {
@@ -261,34 +241,48 @@ int Http2Parser::SubmitResponse(HttpResponse* res) {
     char c_str[256] = {0};
     snprintf(c_str, sizeof(c_str), "%d", res->status_code);
     nvs.push_back(make_nv(":status", c_str));
-    const char* name;
     const char* value;
+    // lowercase field names without mutating the caller's map keys (see SubmitRequest).
+    std::list<std::string> lower_names;
     for (auto& header : res->headers) {
-        name = header.first.c_str();
+        lower_names.push_back(header.first);
+        std::string& name = lower_names.back();
+        hv_strlower(&name[0]);
         value = header.second.c_str();
-        hv_strlower((char*)name);
-        if (strcmp(name, "connection") == 0) {
+        if (name == "connection") {
             // HTTP2 default keep-alive
             continue;
         }
-        if (strcmp(name, "content-length") == 0) {
+        if (name == "content-length") {
             // HTTP2 have frame_hd.length
             continue;
         }
-        nvs.push_back(make_nv2(name, value, header.first.size(), header.second.size()));
+        nvs.push_back(make_nv2(name.c_str(), value, name.size(), header.second.size()));
     }
-    int flags = NGHTTP2_FLAG_END_HEADERS;
-    // we set EOS on DATA frame
     if (stream_id == -1) {
-        // upgrade
+        // h2c upgrade: the HTTP/1.1 request maps to stream 1.
         nghttp2_session_upgrade(session, NULL, 0, NULL);
         stream_id = 1;
     }
-    nghttp2_submit_headers(session, flags, stream_id, NULL, &nvs[0], nvs.size(), NULL);
-    // avoid DATA_SOURCE_COPY, we do not use nghttp2_submit_data
-    // data_prd.read_callback = data_source_read_callback;
-    //nghttp2_submit_response(session, stream_id, &nvs[0], nvs.size(), &data_prd);
-    state = H2_SEND_HEADERS;
+    // Set up the outgoing body as an nghttp2 data_provider (framing + splitting
+    // + flow control handled by nghttp2). For gRPC, prepend the length-prefix.
+    is_grpc = (parsed && parsed->ContentType() == APPLICATION_GRPC);
+    prepareSendBody();
+    nghttp2_data_provider data_prd;
+    data_prd.source.ptr = this;
+    data_prd.read_callback = data_source_read_callback;
+    int ret = nghttp2_submit_response(session, stream_id, &nvs[0], nvs.size(),
+                                      send_len > 0 ? &data_prd : NULL);
+    if (ret != 0) {
+        error = ret;
+        return -1;
+    }
+    // gRPC status travels in a trailing HEADERS frame (grpc-status) with
+    // END_STREAM; the data_provider kept the stream open (NO_END_STREAM).
+    if (is_grpc && type == HTTP_SERVER) {
+        nghttp2_nv nv = make_nv("grpc-status", "0");
+        nghttp2_submit_trailer(session, stream_id, &nv, 1);
+    }
     return 0;
 }
 
@@ -309,6 +303,17 @@ int Http2Parser::InitRequest(HttpRequest* req) {
 }
 
 nghttp2_session_callbacks* Http2Parser::cbs = NULL;
+
+void Http2Parser::initCallbacks() {
+    // thread-safe one-time init (multi-worker servers construct concurrently).
+    static std::once_flag once;
+    std::call_once(once, []() {
+        nghttp2_session_callbacks_new(&cbs);
+        nghttp2_session_callbacks_set_on_header_callback(cbs, on_header_callback);
+        nghttp2_session_callbacks_set_on_data_chunk_recv_callback(cbs, on_data_chunk_recv_callback);
+        nghttp2_session_callbacks_set_on_frame_recv_callback(cbs, on_frame_recv_callback);
+    });
+}
 
 int on_header_callback(nghttp2_session *session,
     const nghttp2_frame *frame,
@@ -403,8 +408,22 @@ int on_frame_recv_callback(nghttp2_session *session,
         hp->state = H2_RECV_PING;
         break;
     case NGHTTP2_RST_STREAM:
+        // peer aborted the stream: surface the error and mark complete so the
+        // recv loop / IsComplete() doesn't hang waiting for END_STREAM.
+        hp->error = (int)frame->rst_stream.error_code;
+        hp->stream_closed = 1;
+        hp->frame_type_when_stream_closed = HTTP2_RST_STREAM;
+        if (hp->parsed && hp->parsed->http_cb) {
+            hp->parsed->http_cb(hp->parsed, HP_MESSAGE_COMPLETE, NULL, 0);
+        }
+        return 0;
+    case NGHTTP2_GOAWAY:
+        // peer is closing the connection; record it (nghttp2 tracks state).
+        hp->error = (int)frame->goaway.error_code;
+        return 0;
     case NGHTTP2_WINDOW_UPDATE:
-        // ignore
+        // flow-control window opened; deferred DATA will be sent on next
+        // GetSendData drain. Nothing to do here.
         return 0;
     default:
         break;

--- a/http/Http2Parser.cpp
+++ b/http/Http2Parser.cpp
@@ -56,10 +56,16 @@ static ssize_t data_source_read_callback(nghttp2_session *session,
     }
     if (hp->send_off >= hp->send_len) {
         *data_flags |= NGHTTP2_DATA_FLAG_EOF;
-        // gRPC carries the status in trailing HEADERS, so keep the stream open
-        // for the trailer; otherwise nghttp2 sets END_STREAM here.
+        // gRPC carries the status in a trailing HEADERS frame. Keep the stream
+        // open (NO_END_STREAM) and submit the trailer HERE -- nghttp2 requires
+        // the trailer be submitted only after EOF+NO_END_STREAM is set on the
+        // final DATA (submit_trailer may be called from this callback). Doing it
+        // earlier (right after submit_response) makes nghttp2 end the stream with
+        // the trailer and drop the not-yet-produced DATA.
         if (hp->is_grpc && hp->type == HTTP_SERVER) {
             *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+            nghttp2_nv nv = make_nv("grpc-status", "0");
+            nghttp2_submit_trailer(session, stream_id, &nv, 1);
         }
     }
     return (ssize_t)n;
@@ -125,7 +131,9 @@ int Http2Parser::FeedRecvData(const char* data, size_t len) {
         return (int)ret;
     }
     if ((size_t)ret != len) {
-        error = (int)ret;
+        // mem_recv normally consumes all input; a short consume is a protocol
+        // error. Record a real error code (not the byte count) for GetError().
+        error = NGHTTP2_ERR_PROTO;
     }
     return (int)ret;
 }
@@ -283,12 +291,8 @@ int Http2Parser::SubmitResponse(HttpResponse* res) {
         error = ret;
         return -1;
     }
-    // gRPC status travels in a trailing HEADERS frame (grpc-status) with
-    // END_STREAM; the data_provider kept the stream open (NO_END_STREAM).
-    if (is_grpc && type == HTTP_SERVER) {
-        nghttp2_nv nv = make_nv("grpc-status", "0");
-        nghttp2_submit_trailer(session, stream_id, &nv, 1);
-    }
+    // NOTE: for gRPC the grpc-status trailer is submitted inside the data
+    // provider read callback (after EOF+NO_END_STREAM), per nghttp2's contract.
     return 0;
 }
 

--- a/http/Http2Parser.cpp
+++ b/http/Http2Parser.cpp
@@ -64,8 +64,20 @@ static ssize_t data_source_read_callback(nghttp2_session *session,
         // the trailer and drop the not-yet-produced DATA.
         if (hp->is_grpc && hp->type == HTTP_SERVER) {
             *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
-            nghttp2_nv nv = make_nv("grpc-status", "0");
-            nghttp2_submit_trailer(session, stream_id, &nv, 1);
+            // grpc-status defaults to 0 (OK); the handler may override it (and
+            // add grpc-message) via resp->headers. nghttp2 copies name/value,
+            // and submited outlives the stream, so c_str() is safe here.
+            HttpResponse* res = (HttpResponse*)hp->submited;
+            auto it = res->headers.find("grpc-status");
+            const char* status = (it != res->headers.end()) ? it->second.c_str() : "0";
+            nghttp2_nv nvs[2];
+            int n = 0;
+            nvs[n++] = make_nv("grpc-status", status);
+            auto mit = res->headers.find("grpc-message");
+            if (mit != res->headers.end()) {
+                nvs[n++] = make_nv("grpc-message", mit->second.c_str());
+            }
+            nghttp2_submit_trailer(session, stream_id, nvs, n);
         }
     }
     return (ssize_t)n;
@@ -269,6 +281,10 @@ int Http2Parser::SubmitResponse(HttpResponse* res) {
         }
         if (name == "content-length") {
             // HTTP2 have frame_hd.length
+            continue;
+        }
+        if (name == "grpc-status" || name == "grpc-message") {
+            // trailer-only fields, emitted in the data_provider read callback
             continue;
         }
         nvs.push_back(make_nv2(name.c_str(), value, name.size(), header.second.size()));

--- a/http/Http2Parser.h
+++ b/http/Http2Parser.h
@@ -9,15 +9,6 @@
 #include "nghttp2/nghttp2.h"
 
 enum http2_session_state {
-    H2_SEND_MAGIC,
-    H2_SEND_SETTINGS,
-    H2_SEND_PING,
-    H2_SEND_HEADERS,
-    H2_SEND_DATA_FRAME_HD,
-    H2_SEND_DATA,
-    H2_SEND_DONE,
-
-    H2_WANT_SEND,
     H2_WANT_RECV,
 
     H2_RECV_SETTINGS,
@@ -26,6 +17,14 @@ enum http2_session_state {
     H2_RECV_DATA,
 };
 
+// HTTP/2 parser adapter over nghttp2.
+//
+// LIMITATION: a single active stream per session. There is one `parsed` /
+// `submited` / `stream_id`, so header/data callbacks all target the same
+// message regardless of frame stream_id. This matches libhv's one-request-
+// per-connection HTTP usage (sync/async client, HttpHandler). True concurrent
+// multiplexing (multiple in-flight streams on one connection) is NOT supported
+// and would merge streams' data; do not rely on it.
 class Http2Parser : public HttpParser {
 public:
     static nghttp2_session_callbacks* cbs;
@@ -37,12 +36,21 @@ public:
     int stream_id;
     int stream_closed;
     int frame_type_when_stream_closed;
-    // http2_frame_hd + grpc_message_hd
-    // at least HTTP2_FRAME_HDLEN + GRPC_MESSAGE_HDLEN = 9 + 5 = 14
-    unsigned char                   frame_hdbuf[32];
+    // outgoing body cursor for the nghttp2 data_provider read callback.
+    // For gRPC, send_body holds the 5-byte-length-prefixed payload.
+    const char*                     send_buf;
+    size_t                          send_len;
+    size_t                          send_off;
+    std::string                     send_body;   // owns grpc-framed payload
+    bool                            is_grpc;
 
     Http2Parser(http_session_type type = HTTP_CLIENT);
     virtual ~Http2Parser();
+
+    static void initCallbacks();
+
+    // stage submited body into the send cursor (grpc-frames it when needed)
+    void prepareSendBody();
 
     virtual int GetSendData(char** data, size_t* len);
     virtual int FeedRecvData(const char* data, size_t len);
@@ -56,11 +64,15 @@ public:
     }
 
     virtual bool WantSend() {
-        return state <= H2_WANT_SEND;
+        // nghttp2 still has queued frames (DATA deferred by flow control,
+        // SETTINGS/PING ACK, WINDOW_UPDATE, trailers, ...) to write out.
+        return session && nghttp2_session_want_write(session);
     }
 
     virtual bool IsComplete() {
-        return stream_closed && (frame_type_when_stream_closed == HTTP2_DATA || frame_type_when_stream_closed == HTTP2_HEADERS);
+        return stream_closed && (frame_type_when_stream_closed == HTTP2_DATA ||
+                                 frame_type_when_stream_closed == HTTP2_HEADERS ||
+                                 frame_type_when_stream_closed == HTTP2_RST_STREAM);
     }
 
     virtual int GetError() {

--- a/http/client/AsyncHttpClient.cpp
+++ b/http/client/AsyncHttpClient.cpp
@@ -145,6 +145,16 @@ int AsyncHttpClient::doTaskWithAddr(const HttpClientTaskPtr& task, const sockadd
             channel->close();
             return;
         }
+        // HTTP2: flush frames nghttp2 queued while consuming input (SETTINGS/
+        // PING ACK, WINDOW_UPDATE, and request-body DATA deferred by flow
+        // control until the peer's WINDOW_UPDATE arrived).
+        if (ctx->task->req->http_major == 2 && ctx->parser->WantSend()) {
+            char* sdata = NULL;
+            size_t slen = 0;
+            while (ctx->parser->GetSendData(&sdata, &slen) > 0) {
+                if (sdata && slen) channel->write(sdata, slen);
+            }
+        }
         if (ctx->parser->IsComplete()) {
             auto& req = ctx->task->req;
             auto& resp = ctx->resp;

--- a/http/client/HttpClient.cpp
+++ b/http/client/HttpClient.cpp
@@ -236,16 +236,6 @@ int http_client_connect(http_client_t* cli, const char* host, int port, int http
             closesocket(connfd);
             return NABS(ERR_NEW_SSL_CTX);
         }
-#ifdef WITH_OPENSSL
-        // Offer ALPN "h2" only when HTTP/2 is intended, so an h2-capable server
-        // negotiates it (real https servers require ALPN, not prior-knowledge).
-        // Must NOT offer h2 for an http/1.1 request: the server might select h2
-        // while we run an http/1.1 parser. Only mutate a ctx we allocated.
-        if (cli->http_version == 2 && cli->alloced_ssl_ctx) {
-            static unsigned char s_alpn_protos[] = "\x02h2\x08http/1.1";
-            hssl_ctx_set_alpn_protos(ssl_ctx, s_alpn_protos, sizeof(s_alpn_protos) - 1);
-        }
-#endif
         cli->ssl = hssl_new(ssl_ctx, connfd);
         if (cli->ssl == NULL) {
             closesocket(connfd);
@@ -254,6 +244,17 @@ int http_client_connect(http_client_t* cli, const char* host, int port, int http
         if (!is_ipaddr(host)) {
             hssl_set_sni_hostname(cli->ssl, host);
         }
+#ifdef WITH_OPENSSL
+        // Offer ALPN "h2" only when HTTP/2 is intended, so an h2-capable server
+        // negotiates it (real https servers require ALPN, not prior-knowledge).
+        // Set it per-connection on the SSL object (not the shared ctx), so it
+        // works with any ctx source (user/global/allocated) and never leaks h2
+        // into other clients or http/1.1 requests.
+        if (cli->http_version == 2) {
+            static unsigned char s_alpn_protos[] = "\x02h2\x08http/1.1";
+            hssl_set_alpn_protos(cli->ssl, s_alpn_protos, sizeof(s_alpn_protos) - 1);
+        }
+#endif
         unsigned int elapsed = gettick_ms() - start_time;
         int ssl_timeout = blocktime - (int)elapsed;
         if (ssl_timeout <= 0) {

--- a/http/client/HttpClient.cpp
+++ b/http/client/HttpClient.cpp
@@ -359,18 +359,27 @@ connect:
         }
         CHECK_TIMEOUT
 #ifdef WITH_OPENSSL
-        // If we intended HTTP/2 but the TLS peer did not negotiate "h2" via
-        // ALPN, fall back to HTTP/1.1 so we don't run an h2 parser over an
-        // http/1.1 response. (Only meaningful for https; h2c prior-knowledge
-        // over plaintext keeps http_major==2.)
+        // Reconcile the parser with the ALPN protocol actually negotiated on
+        // this (re)connect. For an intended-h2 https request: use an h2 parser
+        // iff the peer selected "h2", otherwise HTTP/1.1. Correcting in BOTH
+        // directions matters when one http_client_t is reused across hosts --
+        // a stale V1 parser (from a previous non-h2 host) must be upgraded back
+        // to h2 for an h2 host, and vice versa.
         if (https && req->http_major == 2 && cli->ssl) {
             unsigned int alpn_len = 0;
             const char* alpn = hssl_ssl_alpn_selected(cli->ssl, &alpn_len);
             bool is_h2 = (alpn && alpn_len == 2 && memcmp(alpn, "h2", 2) == 0);
-            if (!is_h2) {
+            int want_major = is_h2 ? 2 : 1;
+            if (want_major == 1) {
+                // fall back to HTTP/1.1 (not 1.0: keep-alive semantics)
                 req->http_major = 1;
-                req->http_minor = 1;  // HTTP/1.1, not 1.0 (keep-alive semantics)
-                cli->parser = HttpParserPtr(HttpParser::New(HTTP_CLIENT, HTTP_V1));
+                req->http_minor = 1;
+            }
+            // rebuild the parser if it doesn't match the negotiated version
+            if (cli->parser == NULL || cli->http_version != want_major) {
+                cli->parser = HttpParserPtr(HttpParser::New(HTTP_CLIENT,
+                    (http_version)(want_major == 2 ? HTTP_V2 : HTTP_V1)));
+                cli->http_version = want_major;
             }
         }
 #endif

--- a/http/client/HttpClient.cpp
+++ b/http/client/HttpClient.cpp
@@ -369,6 +369,7 @@ connect:
             bool is_h2 = (alpn && alpn_len == 2 && memcmp(alpn, "h2", 2) == 0);
             if (!is_h2) {
                 req->http_major = 1;
+                req->http_minor = 1;  // HTTP/1.1, not 1.0 (keep-alive semantics)
                 cli->parser = HttpParserPtr(HttpParser::New(HTTP_CLIENT, HTTP_V1));
             }
         }

--- a/http/client/HttpClient.cpp
+++ b/http/client/HttpClient.cpp
@@ -22,7 +22,8 @@ using namespace hv;
 struct http_client_s {
     std::string  host;
     int          port;
-    int          https;
+    unsigned char https;         // 0/1
+    unsigned char http_version;  // intended HTTP version for the next connect (1 or 2)
     int          timeout; // s
     http_headers headers;
     // http_proxy
@@ -43,7 +44,6 @@ struct http_client_s {
     hssl_t          ssl;
     hssl_ctx_t      ssl_ctx;
     bool            alloced_ssl_ctx;
-    int             http_version;   // intended HTTP version for the next connect (1 or 2)
     HttpParserPtr   parser;
     // for async
     std::mutex                              mutex_;
@@ -94,7 +94,7 @@ http_client_t* http_client_new(const char* host, int port, int https) {
     http_client_t* cli = new http_client_t;
     if (host) cli->host = host;
     cli->port = port;
-    cli->https = https;
+    cli->https = https ? 1 : 0;
     cli->headers["Connection"] = "keep-alive";
     return cli;
 }

--- a/http/client/HttpClient.cpp
+++ b/http/client/HttpClient.cpp
@@ -43,6 +43,7 @@ struct http_client_s {
     hssl_t          ssl;
     hssl_ctx_t      ssl_ctx;
     bool            alloced_ssl_ctx;
+    int             http_version;   // intended HTTP version for the next connect (1 or 2)
     HttpParserPtr   parser;
     // for async
     std::mutex                              mutex_;
@@ -63,6 +64,7 @@ struct http_client_s {
         ssl = NULL;
         ssl_ctx = NULL;
         alloced_ssl_ctx = false;
+        http_version = 1;
     }
 
     ~http_client_s() {
@@ -234,6 +236,16 @@ int http_client_connect(http_client_t* cli, const char* host, int port, int http
             closesocket(connfd);
             return NABS(ERR_NEW_SSL_CTX);
         }
+#ifdef WITH_OPENSSL
+        // Offer ALPN "h2" only when HTTP/2 is intended, so an h2-capable server
+        // negotiates it (real https servers require ALPN, not prior-knowledge).
+        // Must NOT offer h2 for an http/1.1 request: the server might select h2
+        // while we run an http/1.1 parser. Only mutate a ctx we allocated.
+        if (cli->http_version == 2 && cli->alloced_ssl_ctx) {
+            static unsigned char s_alpn_protos[] = "\x02h2\x08http/1.1";
+            hssl_ctx_set_alpn_protos(ssl_ctx, s_alpn_protos, sizeof(s_alpn_protos) - 1);
+        }
+#endif
         cli->ssl = hssl_new(ssl_ctx, connfd);
         if (cli->ssl == NULL) {
             closesocket(connfd);
@@ -339,12 +351,28 @@ static int http_client_exec(http_client_t* cli, HttpRequest* req, HttpResponse* 
     if (connfd <= 0 || cli->host != req->host || cli->port != req->port) {
         cli->host = req->host;
         cli->port = req->port;
+        cli->http_version = req->http_major;  // gates the ALPN "h2" offer in connect
 connect:
         connfd = http_client_connect(cli, req->host.c_str(), req->port, https, connect_timeout);
         if (connfd < 0) {
             return connfd;
         }
         CHECK_TIMEOUT
+#ifdef WITH_OPENSSL
+        // If we intended HTTP/2 but the TLS peer did not negotiate "h2" via
+        // ALPN, fall back to HTTP/1.1 so we don't run an h2 parser over an
+        // http/1.1 response. (Only meaningful for https; h2c prior-knowledge
+        // over plaintext keeps http_major==2.)
+        if (https && req->http_major == 2 && cli->ssl) {
+            unsigned int alpn_len = 0;
+            const char* alpn = hssl_ssl_alpn_selected(cli->ssl, &alpn_len);
+            bool is_h2 = (alpn && alpn_len == 2 && memcmp(alpn, "h2", 2) == 0);
+            if (!is_h2) {
+                req->http_major = 1;
+                cli->parser = HttpParserPtr(HttpParser::New(HTTP_CLIENT, HTTP_V1));
+            }
+        }
+#endif
     }
 
     cli->parser->SubmitRequest(req);
@@ -404,6 +432,24 @@ recv:
         int nparse = cli->parser->FeedRecvData(recvbuf, nrecv);
         if (nparse != nrecv) {
             return ERR_PARSE;
+        }
+        // HTTP2: flush frames nghttp2 queued while consuming this input --
+        // WINDOW_UPDATE (as we consume the response body), SETTINGS/PING ACK,
+        // and request-body DATA that was deferred by flow control. Drain inline
+        // (must NOT jump back to the `send:` label, which would re-run
+        // InitResponse and wipe the accumulated response body).
+        if (req->http_major == 2) {
+            char* sdata = NULL;
+            size_t slen = 0;
+            while (cli->parser->GetSendData(&sdata, &slen) > 0) {
+                if (req->cancel) goto disconnect;
+                total_nsend = 0;
+                while (total_nsend < (int)slen) {
+                    nsend = http_client_send_data(cli, sdata + total_nsend, slen - total_nsend);
+                    if (nsend <= 0) goto disconnect;
+                    total_nsend += nsend;
+                }
+            }
         }
     } while(!cli->parser->IsComplete());
 

--- a/http/client/HttpClient.cpp
+++ b/http/client/HttpClient.cpp
@@ -368,7 +368,7 @@ connect:
         // to h2 for an h2 host, and vice versa.
         if (https && req->http_major == 2 && cli->ssl) {
             unsigned int alpn_len = 0;
-            const char* alpn = hssl_ssl_alpn_selected(cli->ssl, &alpn_len);
+            const char* alpn = hssl_get_alpn_proto(cli->ssl, &alpn_len);
             bool is_h2 = (alpn && alpn_len == 2 && memcmp(alpn, "h2", 2) == 0);
             int want_major = is_h2 ? 2 : 1;
             if (want_major == 1) {

--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -91,7 +91,7 @@ bool HttpHandler::Init(int http_version) {
             // response over a different connection.
             hio_t* hio = io;
             uint32_t hid = hio_id(io);
-            writer->onhttp2response = [hio, hid]() {
+            writer->submitHttp2Response = [hio, hid]() {
                 hloop_t* loop = hevent_loop(hio);
                 hevent_t ev;
                 memset(&ev, 0, sizeof(ev));

--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -81,6 +81,31 @@ bool HttpHandler::Init(int http_version) {
         tid = hloop_tid(loop);
         writer = std::make_shared<HttpResponseWriter>(io, resp);
         writer->status = hv::SocketChannel::CONNECTED;
+        if (protocol == HTTP_V2) {
+            // Async handlers run on a worker thread but the nghttp2 session is
+            // not thread-safe, so the writer posts the h2 response submit back
+            // to this io's loop thread (hloop_post_event is thread-safe).
+            hio_t* hio = io;
+            writer->onhttp2response = [hio]() {
+                hloop_t* loop = hevent_loop(hio);
+                hevent_t ev;
+                memset(&ev, 0, sizeof(ev));
+                ev.loop = loop;
+                ev.userdata = hio;
+                ev.cb = [](hevent_t* ev) {
+                    hio_t* io = (hio_t*)ev->userdata;
+                    // handler is stored as the io userdata; NULL after close.
+                    HttpHandler* handler = (HttpHandler*)hevent_userdata(io);
+                    if (handler && handler->parser) {
+                        // async left state at HANDLE_CONTINUE; move to WANT_SEND
+                        // so GetSendData drives the h2 send instead of bailing.
+                        handler->state = WANT_SEND;
+                        handler->SendHttpResponse();
+                    }
+                };
+                hloop_post_event(loop, &ev);
+            };
+        }
     } else {
         pid = hv_getpid();
         tid = hv_gettid();
@@ -753,6 +778,13 @@ int HttpHandler::FeedRecvData(const char* data, size_t len) {
             error = ERR_PARSE;
             return -1;
         }
+        // HTTP2: flush frames nghttp2 queued while consuming this input --
+        // SETTINGS/PING ACK, WINDOW_UPDATE, and DATA that was deferred by flow
+        // control until the peer's WINDOW_UPDATE just arrived. Without this a
+        // response body larger than the stream window (64KB) would stall.
+        if (protocol == HttpHandler::HTTP_V2) {
+            flushHttp2Send();
+        }
         break;
     case HttpHandler::WEBSOCKET:
         nfeed = ws_parser->FeedRecvData(data, len);
@@ -877,6 +909,22 @@ int HttpHandler::SendHttpResponse(bool submit) {
     if (submit) parser->SubmitResponse(resp.get());
     while (GetSendData(&data, &len)) {
         // printf("GetSendData %d\n", (int)len);
+        if (data && len) {
+            hio_write(io, data, len);
+            total_len += len;
+        }
+    }
+    return total_len;
+}
+
+// Flush any frames nghttp2 has queued (ACKs, WINDOW_UPDATE, flow-controlled
+// DATA). Drives the parser directly (no HttpHandler send-state machine) so it
+// is safe to call from the recv path. HTTP/2 only.
+int HttpHandler::flushHttp2Send() {
+    if (!io || !parser) return 0;
+    char* data = NULL;
+    size_t len = 0, total_len = 0;
+    while (parser->GetSendData(&data, &len) > 0) {
         if (data && len) {
             hio_write(io, data, len);
             total_len += len;

--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -791,7 +791,7 @@ int HttpHandler::FeedRecvData(const char* data, size_t len) {
         // control until the peer's WINDOW_UPDATE just arrived. Without this a
         // response body larger than the stream window (64KB) would stall.
         if (protocol == HttpHandler::HTTP_V2) {
-            flushHttp2Send();
+            flushHttp2();
         }
         break;
     case HttpHandler::WEBSOCKET:
@@ -928,7 +928,7 @@ int HttpHandler::SendHttpResponse(bool submit) {
 // Flush any frames nghttp2 has queued (ACKs, WINDOW_UPDATE, flow-controlled
 // DATA). Drives the parser directly (no HttpHandler send-state machine) so it
 // is safe to call from the recv path. HTTP/2 only.
-int HttpHandler::flushHttp2Send() {
+int HttpHandler::flushHttp2() {
     if (!io || !parser) return 0;
     char* data = NULL;
     size_t len = 0, total_len = 0;

--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -790,8 +790,14 @@ int HttpHandler::FeedRecvData(const char* data, size_t len) {
         // SETTINGS/PING ACK, WINDOW_UPDATE, and DATA that was deferred by flow
         // control until the peer's WINDOW_UPDATE just arrived. Without this a
         // response body larger than the stream window (64KB) would stall.
-        if (protocol == HttpHandler::HTTP_V2) {
-            flushHttp2();
+        // Drives the parser directly (not the send-state machine) so it is safe
+        // on the recv path.
+        if (protocol == HttpHandler::HTTP_V2 && io && parser) {
+            char* sdata = NULL;
+            size_t slen = 0;
+            while (parser->GetSendData(&sdata, &slen) > 0) {
+                if (sdata && slen) hio_write(io, sdata, slen);
+            }
         }
         break;
     case HttpHandler::WEBSOCKET:
@@ -917,22 +923,6 @@ int HttpHandler::SendHttpResponse(bool submit) {
     if (submit) parser->SubmitResponse(resp.get());
     while (GetSendData(&data, &len)) {
         // printf("GetSendData %d\n", (int)len);
-        if (data && len) {
-            hio_write(io, data, len);
-            total_len += len;
-        }
-    }
-    return total_len;
-}
-
-// Flush any frames nghttp2 has queued (ACKs, WINDOW_UPDATE, flow-controlled
-// DATA). Drives the parser directly (no HttpHandler send-state machine) so it
-// is safe to call from the recv path. HTTP/2 only.
-int HttpHandler::flushHttp2() {
-    if (!io || !parser) return 0;
-    char* data = NULL;
-    size_t len = 0, total_len = 0;
-    while (parser->GetSendData(&data, &len) > 0) {
         if (data && len) {
             hio_write(io, data, len);
             total_len += len;

--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -85,15 +85,23 @@ bool HttpHandler::Init(int http_version) {
             // Async handlers run on a worker thread but the nghttp2 session is
             // not thread-safe, so the writer posts the h2 response submit back
             // to this io's loop thread (hloop_post_event is thread-safe).
+            // Capture hio_id too: a fd (hence hio_t*) can be reused by a new
+            // connection after close, so verify the id still matches before
+            // touching the handler, otherwise a late post could send this
+            // response over a different connection.
             hio_t* hio = io;
-            writer->onhttp2response = [hio]() {
+            uint32_t hid = hio_id(io);
+            writer->onhttp2response = [hio, hid]() {
                 hloop_t* loop = hevent_loop(hio);
                 hevent_t ev;
                 memset(&ev, 0, sizeof(ev));
                 ev.loop = loop;
                 ev.userdata = hio;
+                ev.event_id = hid;   // carry the captured hio id for validation
                 ev.cb = [](hevent_t* ev) {
                     hio_t* io = (hio_t*)ev->userdata;
+                    // stale post: fd was reused by another connection after close
+                    if (hio_id(io) != ev->event_id) return;
                     // handler is stored as the io userdata; NULL after close.
                     HttpHandler* handler = (HttpHandler*)hevent_userdata(io);
                     if (handler && handler->parser) {

--- a/http/server/HttpHandler.h
+++ b/http/server/HttpHandler.h
@@ -115,6 +115,8 @@ public:
     int GetSendData(char** data, size_t* len);
 
     int SendHttpResponse(bool submit = true);
+    // HTTP/2: flush nghttp2's queued frames (ACKs, WINDOW_UPDATE, deferred DATA)
+    int flushHttp2Send();
     int SendHttpStatusResponse(http_status status_code);
 
     // HTTP2

--- a/http/server/HttpHandler.h
+++ b/http/server/HttpHandler.h
@@ -115,8 +115,6 @@ public:
     int GetSendData(char** data, size_t* len);
 
     int SendHttpResponse(bool submit = true);
-    // HTTP/2: flush nghttp2's queued frames (ACKs, WINDOW_UPDATE, deferred DATA)
-    int flushHttp2();
     int SendHttpStatusResponse(http_status status_code);
 
     // HTTP2

--- a/http/server/HttpHandler.h
+++ b/http/server/HttpHandler.h
@@ -116,7 +116,7 @@ public:
 
     int SendHttpResponse(bool submit = true);
     // HTTP/2: flush nghttp2's queued frames (ACKs, WINDOW_UPDATE, deferred DATA)
-    int flushHttp2Send();
+    int flushHttp2();
     int SendHttpStatusResponse(http_status status_code);
 
     // HTTP2

--- a/http/server/HttpResponseWriter.cpp
+++ b/http/server/HttpResponseWriter.cpp
@@ -66,7 +66,7 @@ int HttpResponseWriter::WriteResponse(HttpResponse* resp) {
     if (isHttp2()) {
         if (resp != response.get()) *response = *resp;
         end = SEND_END;
-        onhttp2response();
+        submitHttp2Response();
         return (int)response->body.size();
     }
     bool is_dump_headers = state == SEND_BEGIN ? true : false;
@@ -105,7 +105,7 @@ int HttpResponseWriter::End(const char* buf /* = NULL */, int len /* = -1 */) {
             if (len == -1) len = strlen(buf);
             response->body.append(buf, len);
         }
-        onhttp2response();
+        submitHttp2Response();
         return (int)response->body.size();
     }
 

--- a/http/server/HttpResponseWriter.cpp
+++ b/http/server/HttpResponseWriter.cpp
@@ -57,6 +57,13 @@ int HttpResponseWriter::WriteResponse(HttpResponse* resp) {
         response->status_code = HTTP_STATUS_INTERNAL_SERVER_ERROR;
         return 0;
     }
+    // HTTP/2: submit via the handler's nghttp2 session (see End()).
+    if (isHttp2()) {
+        if (resp != response.get()) *response = *resp;
+        end = SEND_END;
+        onhttp2response();
+        return (int)response->body.size();
+    }
     bool is_dump_headers = state == SEND_BEGIN ? true : false;
     std::string msg = resp->Dump(is_dump_headers, true);
     state = SEND_BODY;
@@ -82,6 +89,18 @@ int HttpResponseWriter::End(const char* buf /* = NULL */, int len /* = -1 */) {
 
     if (!isConnected()) {
         return -1;
+    }
+
+    // HTTP/2: the writer can't produce h2 frames. Collect the full body into
+    // response and hand it to the handler's nghttp2 session (on the IO loop).
+    // Streaming methods (WriteChunked/SSE) are not supported over h2.
+    if (isHttp2()) {
+        if (buf) {
+            if (len == -1) len = strlen(buf);
+            response->body.append(buf, len);
+        }
+        onhttp2response();
+        return (int)response->body.size();
     }
 
     int ret = 0;

--- a/http/server/HttpResponseWriter.cpp
+++ b/http/server/HttpResponseWriter.cpp
@@ -3,6 +3,10 @@
 namespace hv {
 
 int HttpResponseWriter::EndHeaders(const char* key /* = NULL */, const char* value /* = NULL */) {
+    // Streaming/incremental HTTP/1 serialization can't produce h2 frames; over
+    // h2 only a one-shot response (End/WriteResponse) is supported. Reject here
+    // instead of writing raw HTTP/1 bytes into the h2 frame stream.
+    if (isHttp2()) return -1;
     if (state != SEND_BEGIN) return -1;
     if (key && value) {
         response->SetHeader(key, value);
@@ -19,6 +23,7 @@ int HttpResponseWriter::EndHeaders(const char* key /* = NULL */, const char* val
 }
 
 int HttpResponseWriter::WriteChunked(const char* buf, int len /* = -1 */) {
+    if (isHttp2()) return -1;   // chunked is HTTP/1-only; not supported over h2
     int ret = 0;
     if (len == -1) len = strlen(buf);
     if (state == SEND_BEGIN) {
@@ -71,6 +76,7 @@ int HttpResponseWriter::WriteResponse(HttpResponse* resp) {
 }
 
 int HttpResponseWriter::SSEvent(const std::string& data, const char* event /* = "message" */) {
+    if (isHttp2()) return -1;   // SSE is a streaming HTTP/1 pattern; not supported over h2
     if (state == SEND_BEGIN) {
         EndHeaders("Content-Type", "text/event-stream");
     }

--- a/http/server/HttpResponseWriter.h
+++ b/http/server/HttpResponseWriter.h
@@ -17,6 +17,13 @@ public:
         SEND_CHUNKED_END,
         SEND_END,
     } state: 8, end: 8;
+    // HTTP/2: set by HttpHandler when the connection is h2. The raw HTTP/1
+    // serialization in this writer cannot produce h2 frames, so on h2 the
+    // one-shot response (End / WriteResponse) is funneled through this hook,
+    // which submits the response via the handler's nghttp2 session on the IO
+    // loop thread. Streaming (WriteChunked/SSE) over h2 is not supported.
+    std::function<void()> onhttp2response;
+
     HttpResponseWriter(hio_t* io, const HttpResponsePtr& resp)
         : SocketChannel(io)
         , response(resp)
@@ -24,6 +31,8 @@ public:
         , end(SEND_BEGIN)
     {}
     ~HttpResponseWriter() {}
+
+    bool isHttp2() const { return (bool)onhttp2response; }
 
     // Begin -> End
     // Begin -> WriteResponse -> End

--- a/http/server/HttpResponseWriter.h
+++ b/http/server/HttpResponseWriter.h
@@ -22,7 +22,7 @@ public:
     // one-shot response (End / WriteResponse) is funneled through this hook,
     // which submits the response via the handler's nghttp2 session on the IO
     // loop thread. Streaming (WriteChunked/SSE) over h2 is not supported.
-    std::function<void()> onhttp2response;
+    std::function<void()> submitHttp2Response;
 
     HttpResponseWriter(hio_t* io, const HttpResponsePtr& resp)
         : SocketChannel(io)
@@ -32,7 +32,7 @@ public:
     {}
     ~HttpResponseWriter() {}
 
-    bool isHttp2() const { return (bool)onhttp2response; }
+    bool isHttp2() const { return (bool)submitHttp2Response; }
 
     // Begin -> End
     // Begin -> WriteResponse -> End

--- a/ssl/hssl.h
+++ b/ssl/hssl.h
@@ -82,12 +82,16 @@ HV_EXPORT int hssl_close(hssl_t ssl);
 
 HV_EXPORT int hssl_set_sni_hostname(hssl_t ssl, const char* hostname);
 
+// ALPN is currently implemented only for the OpenSSL backend. With other TLS
+// backends (gnutls/mbedtls/appletls/wintls) these are not declared, so HTTP/2
+// over TLS falls back to prior-knowledge (and downgrades to HTTP/1.1 against
+// servers that require ALPN negotiation).
 #ifdef WITH_OPENSSL
 HV_EXPORT int hssl_ctx_set_alpn_protos(hssl_ctx_t ssl_ctx, const unsigned char* protos, unsigned int protos_len);
 // Client-side ALPN, set per-connection on the SSL object (not the shared ctx).
 HV_EXPORT int hssl_set_alpn_protos(hssl_t ssl, const unsigned char* protos, unsigned int protos_len);
 // Returns the negotiated ALPN protocol (e.g. "h2"), not NUL-terminated; *len set. NULL if none.
-HV_EXPORT const char* hssl_ssl_alpn_selected(hssl_t ssl, unsigned int* len);
+HV_EXPORT const char* hssl_get_alpn_proto(hssl_t ssl, unsigned int* len);
 #endif
 
 END_EXTERN_C

--- a/ssl/hssl.h
+++ b/ssl/hssl.h
@@ -84,6 +84,8 @@ HV_EXPORT int hssl_set_sni_hostname(hssl_t ssl, const char* hostname);
 
 #ifdef WITH_OPENSSL
 HV_EXPORT int hssl_ctx_set_alpn_protos(hssl_ctx_t ssl_ctx, const unsigned char* protos, unsigned int protos_len);
+// Returns the negotiated ALPN protocol (e.g. "h2"), not NUL-terminated; *len set. NULL if none.
+HV_EXPORT const char* hssl_ssl_alpn_selected(hssl_t ssl, unsigned int* len);
 #endif
 
 END_EXTERN_C

--- a/ssl/hssl.h
+++ b/ssl/hssl.h
@@ -84,6 +84,8 @@ HV_EXPORT int hssl_set_sni_hostname(hssl_t ssl, const char* hostname);
 
 #ifdef WITH_OPENSSL
 HV_EXPORT int hssl_ctx_set_alpn_protos(hssl_ctx_t ssl_ctx, const unsigned char* protos, unsigned int protos_len);
+// Client-side ALPN, set per-connection on the SSL object (not the shared ctx).
+HV_EXPORT int hssl_set_alpn_protos(hssl_t ssl, const unsigned char* protos, unsigned int protos_len);
 // Returns the negotiated ALPN protocol (e.g. "h2"), not NUL-terminated; *len set. NULL if none.
 HV_EXPORT const char* hssl_ssl_alpn_selected(hssl_t ssl, unsigned int* len);
 #endif

--- a/ssl/openssl.c
+++ b/ssl/openssl.c
@@ -188,17 +188,25 @@ static int hssl_ctx_alpn_select_cb(SSL *ssl,
 
 int hssl_ctx_set_alpn_protos(hssl_ctx_t ssl_ctx, const unsigned char* protos, unsigned int protos_len) {
     int ret = -1;
-    // protos is ALPN wire format: length-prefixed, e.g. "\x02h2\x08http/1.1".
-    // NOTE: it must also be NUL-terminated, because the server select callback
-    // derives its length via strlen (SSL_CTX_set_alpn_select_cb passes no length).
+    // Server-side ALPN: select from the client's offer against this list.
+    // protos is ALPN wire format (length-prefixed) and must be NUL-terminated,
+    // because the select callback derives its length via strlen (the OpenSSL
+    // select-cb API passes no length).
+    (void)protos_len;
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
-    // client: offer this ALPN list to the server (returns non-zero on failure)
-    if (SSL_CTX_set_alpn_protos((SSL_CTX*)ssl_ctx, protos, protos_len) != 0) {
-        return -1;
-    }
-    // server: select from the client's offer against this list
     SSL_CTX_set_alpn_select_cb((SSL_CTX*)ssl_ctx, hssl_ctx_alpn_select_cb, (void*)protos);
     ret = 0;
+#endif
+    return ret;
+}
+
+// Client-side ALPN, set per-connection on the SSL object (not the shared ctx),
+// so offering "h2" for one request never leaks into other clients / requests.
+int hssl_set_alpn_protos(hssl_t ssl, const unsigned char* protos, unsigned int protos_len) {
+    int ret = -1;
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+    // returns 0 on success, non-zero on failure (bad wire format, etc.)
+    ret = SSL_set_alpn_protos((SSL*)ssl, protos, protos_len) == 0 ? 0 : -1;
 #endif
     return ret;
 }

--- a/ssl/openssl.c
+++ b/ssl/openssl.c
@@ -188,16 +188,27 @@ static int hssl_ctx_alpn_select_cb(SSL *ssl,
 
 int hssl_ctx_set_alpn_protos(hssl_ctx_t ssl_ctx, const unsigned char* protos, unsigned int protos_len) {
     int ret = -1;
-    // printf("hssl_ctx_set_alpn_protos(%.*s:%u)\n", protos_len, protos, protos_len);
+    // protos is wire format: length-prefixed, e.g. "\x02h2\x08http/1.1".
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
-    // for HSSL_CLIENT
-    // ret = SSL_CTX_set_alpn_protos((SSL_CTX*)ssl_ctx, (const unsigned char*)protos, protos_len);
-
-    // for HSSL_SERVER
+    // client: offer this ALPN list to the server
+    SSL_CTX_set_alpn_protos((SSL_CTX*)ssl_ctx, protos, protos_len);
+    // server: select from the client's offer against this list
     SSL_CTX_set_alpn_select_cb((SSL_CTX*)ssl_ctx, hssl_ctx_alpn_select_cb, (void*)protos);
     ret = 0;
 #endif
     return ret;
+}
+
+// Return the ALPN protocol negotiated on this connection (e.g. "h2"), or NULL.
+// Caller must not free the returned pointer; it is owned by the SSL object.
+const char* hssl_ssl_alpn_selected(hssl_t ssl, unsigned int* len) {
+    const unsigned char* proto = NULL;
+    unsigned int proto_len = 0;
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+    SSL_get0_alpn_selected((SSL*)ssl, &proto, &proto_len);
+#endif
+    if (len) *len = proto_len;
+    return (const char*)proto;
 }
 
 #endif // WITH_OPENSSL

--- a/ssl/openssl.c
+++ b/ssl/openssl.c
@@ -188,10 +188,14 @@ static int hssl_ctx_alpn_select_cb(SSL *ssl,
 
 int hssl_ctx_set_alpn_protos(hssl_ctx_t ssl_ctx, const unsigned char* protos, unsigned int protos_len) {
     int ret = -1;
-    // protos is wire format: length-prefixed, e.g. "\x02h2\x08http/1.1".
+    // protos is ALPN wire format: length-prefixed, e.g. "\x02h2\x08http/1.1".
+    // NOTE: it must also be NUL-terminated, because the server select callback
+    // derives its length via strlen (SSL_CTX_set_alpn_select_cb passes no length).
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
-    // client: offer this ALPN list to the server
-    SSL_CTX_set_alpn_protos((SSL_CTX*)ssl_ctx, protos, protos_len);
+    // client: offer this ALPN list to the server (returns non-zero on failure)
+    if (SSL_CTX_set_alpn_protos((SSL_CTX*)ssl_ctx, protos, protos_len) != 0) {
+        return -1;
+    }
     // server: select from the client's offer against this list
     SSL_CTX_set_alpn_select_cb((SSL_CTX*)ssl_ctx, hssl_ctx_alpn_select_cb, (void*)protos);
     ret = 0;

--- a/ssl/openssl.c
+++ b/ssl/openssl.c
@@ -213,7 +213,7 @@ int hssl_set_alpn_protos(hssl_t ssl, const unsigned char* protos, unsigned int p
 
 // Return the ALPN protocol negotiated on this connection (e.g. "h2"), or NULL.
 // Caller must not free the returned pointer; it is owned by the SSL object.
-const char* hssl_ssl_alpn_selected(hssl_t ssl, unsigned int* len) {
+const char* hssl_get_alpn_proto(hssl_t ssl, unsigned int* len) {
     const unsigned char* proto = NULL;
     unsigned int proto_len = 0;
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation


### PR DESCRIPTION
## What

Fixes three real HTTP/2 defects and completes two paths that could not do HTTP/2 at all.

### 1. Large bodies broke HTTP/2 (framing/flow-control)
The old `Http2Parser` hand-wrote a single DATA frame for the whole body, bypassing nghttp2's framing. Any body > 16KB (peer `SETTINGS_MAX_FRAME_SIZE`) or > the 64KB stream window produced an oversized, flow-control-unaccounted frame → protocol error. Now the body goes through nghttp2's **data_provider**, so nghttp2 splits frames and honors flow control. gRPC framing (5-byte length prefix + `grpc-status` trailer) is preserved.

### 2. Async handlers could not respond over HTTP/2
`HttpResponseWriter` serializes HTTP/1 text straight to the socket, which is malformed on an h2 connection. On h2, the writer now funnels `End()`/`WriteResponse()` through the handler's nghttp2 session, **posted to the IO loop thread** (the session isn't thread-safe; async handlers run on a worker thread). Streaming (`WriteChunked`/SSE) over h2 is out of scope.

### 3. `curl --http2` failed against real https sites (ALPN)
The native client never offered ALPN, so real h2 servers fell back to HTTP/1.1 while libhv ran an h2 parser → failure. Now the client offers ALPN `h2` **only for http2 requests**, and falls back to HTTP/1.1 if the peer didn't negotiate `h2`. Enables client `SSL_CTX_set_alpn_protos` + adds `hssl_ssl_alpn_selected` (OpenSSL only).

### Additional Http2Parser hardening
- Thread-safe callbacks init (`std::call_once`) — multi-worker servers raced on the lazy static.
- Lowercase h2 header names into local copies, not by mutating the caller's `std::map` keys via `c_str()` (UB).
- Surface RST_STREAM / GOAWAY as errors + mark stream complete (recv loop could hang); `ssize_t` for nghttp2 return values; init `error`/`state`.
- Post-recv send flush (server + sync/async client) so SETTINGS/PING ACK, WINDOW_UPDATE and flow-control-deferred DATA are written.
- Documented the single-active-stream limitation.

## Verification
- 256KB GET and POST over h2 (frame splitting + flow control) — round-trip OK.
- Async-handler h2 responses, small and 200KB — OK.
- `bin/curl --http2 https://nghttp2.org/` returns `HTTP/2.0 200 OK`; http/1.1 unaffected.
- `make check` (http/1.1 integration): all `200 OK`, `wrk 641685 OK`.
- `tlv_test` PASS.

## Notes
- All HTTP/2 code is behind `WITH_NGHTTP2` (default off); libhv without nghttp2 is unaffected.
- Client ALPN is behind `WITH_OPENSSL`; other TLS backends (gnutls/mbedtls/appletls/wintls) are unchanged (they have no ALPN plumbing yet).
- Verified locally with nghttp2 1.70 + OpenSSL 3 on macOS.