### PR TITLE
fix(build): -latomic on ARM, hash warning false-positive, Buffer callback docs (#384 #664 #784)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,12 @@ elseif(UNIX AND NOT MINGW)
     if(RT_LIBRARY)
         set(LIBS ${LIBS} rt)
     endif()
+    # Some platforms (e.g. 32-bit ARM / Raspberry Pi) need libatomic for
+    # 64-bit atomics; link it only when available. See issue #384.
+    find_library(ATOMIC_LIBRARY atomic)
+    if(ATOMIC_LIBRARY)
+        set(LIBS ${LIBS} atomic)
+    endif()
 endif()
 
 if(APPLE)

--- a/Makefile.in
+++ b/Makefile.in
@@ -254,6 +254,12 @@ else
 ifeq ($(LINK_RT), )
 	LDFLAGS += -lrt
 endif
+	# Some platforms (e.g. 32-bit ARM / Raspberry Pi) need -latomic for 64-bit
+	# atomics; only link it when the toolchain accepts it. See issue #384.
+	LINK_ATOMIC=$(shell echo "int main(){return 0;}" | $(CC) -x c - -latomic 2>&1)
+ifeq ($(LINK_ATOMIC), )
+	LDFLAGS += -latomic
+endif
 endif
 endif
 

--- a/evpp/Channel.h
+++ b/evpp/Channel.h
@@ -210,8 +210,14 @@ public:
         CLOSED,
     };
     std::atomic<Status>          status;
+    // NOTE: The Buffer* passed to onread/onwrite is only a read-only VIEW over
+    // libhv's internal IO buffer -- it does NOT own the memory. Do not call
+    // mutating methods (resize/copy) on it: they call hv_realloc on a pointer
+    // Buffer does not own and will corrupt memory / crash. To keep the data,
+    // copy it out into your own buffer (e.g. std::string(buf->data(), buf->size())).
     std::function<void(Buffer*)> onread;
     // NOTE: Use Channel::isWriteComplete in onwrite callback to determine whether all data has been written.
+    // See the onread note above: the Buffer* here is also a non-owning view; do not resize/copy it in place.
     std::function<void(Buffer*)> onwrite;
     std::function<void()>        onclose;
     std::shared_ptr<void>        contextPtr_;

--- a/util/md5.c
+++ b/util/md5.c
@@ -32,7 +32,7 @@
         a += b; \
     }
 
-static void HV_MD5Transform(unsigned int state[4],unsigned char block[64]);
+static void HV_MD5Transform(unsigned int state[4],unsigned char *block);
 static void HV_MD5Encode(unsigned char *output,unsigned int *input,unsigned int len);
 static void HV_MD5Decode(unsigned int *output,unsigned char *input,unsigned int len);
 
@@ -108,7 +108,7 @@ void HV_MD5Decode(unsigned int *output,unsigned char *input,unsigned int len) {
     }
 }
 
-void HV_MD5Transform(unsigned int state[4],unsigned char block[64]) {
+void HV_MD5Transform(unsigned int state[4],unsigned char *block) {
     unsigned int a = state[0];
     unsigned int b = state[1];
     unsigned int c = state[2];

--- a/util/sha1.c
+++ b/util/sha1.c
@@ -48,7 +48,7 @@ A million repetitions of "a"
 
 void HV_SHA1Transform(
     uint32_t state[5],
-    const unsigned char buffer[64]
+    const unsigned char *buffer
 )
 {
     uint32_t a, b, c, d, e;

--- a/util/sha1.h
+++ b/util/sha1.h
@@ -22,7 +22,7 @@ BEGIN_EXTERN_C
 
 HV_EXPORT void HV_SHA1Transform(
     uint32_t state[5],
-    const unsigned char buffer[64]
+    const unsigned char *buffer
     );
 
 HV_EXPORT void HV_SHA1Init(


### PR DESCRIPTION
A few small, low-risk fixes for reported build/usability issues.

### #384 — Raspberry Pi: `undefined reference to __atomic_fetch_add_8`
Link `-latomic` on platforms that need it for 64-bit atomics (e.g. 32-bit ARM / Raspberry Pi). Added in **both** `Makefile.in` and `CMakeLists.txt`, probed the same way `-lrt` already is, so it is only linked when the toolchain actually provides libatomic (verified it is correctly skipped on macOS/clang).

### #664 — false-positive `-Wstringop-overflow` in hash functions
Change the `block` / `buffer` parameter of `HV_MD5Transform` / `HV_SHA1Transform` from a fixed-size array (`[64]`) to a plain pointer. The array parameter decays to a pointer anyway, so this is behavior-preserving; it just stops GCC from assuming a 64-byte region on a call path where a smaller buffer is passed. Verified md5/sha1 known-answer vectors still pass (`md5("abc")`, `sha1("abc")`, and multi-block input).

### #784 — `Buffer* buf` in `onread`/`onwrite` easy to misuse → crash
The `Buffer*` handed to `Channel::onread`/`onwrite` is only a non-owning view over libhv's internal IO buffer. Calling mutating methods (`resize`/`copy`) on it runs `hv_realloc` on memory `Buffer` does not own, corrupting the heap. Added a clear doc note at the callback declarations telling users to copy the data out instead.

No functional/ABI change; `make libhv` and CMake both build clean.

Fixes #384
Fixes #664
Fixes #784
