### PR TITLE
feat(udp): UDP multicast join/leave + sender options (#251 #468)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,6 +441,7 @@ evpp: prepare libhv
 	$(CXX) -g -Wall -O0 -std=c++11 -I. -Ibase -Issl -Ievent -Icpputil -Ievpp -o bin/TcpClientEventLoop_test  evpp/TcpClientEventLoop_test.cpp  -Llib -lhv -pthread
 	$(CXX) -g -Wall -O0 -std=c++11 -I. -Ibase -Issl -Ievent -Icpputil -Ievpp -o bin/UdpServer_test           evpp/UdpServer_test.cpp           -Llib -lhv -pthread
 	$(CXX) -g -Wall -O0 -std=c++11 -I. -Ibase -Issl -Ievent -Icpputil -Ievpp -o bin/UdpClient_test           evpp/UdpClient_test.cpp           -Llib -lhv -pthread
+	$(CXX) -g -Wall -O0 -std=c++11 -I. -Ibase -Issl -Ievent -Icpputil -Ievpp -o bin/UdpMulticast_test        evpp/UdpMulticast_test.cpp        -Llib -lhv -pthread
 
 # UNIX only
 webbench: prepare

--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,6 @@ evpp: prepare libhv
 	$(CXX) -g -Wall -O0 -std=c++11 -I. -Ibase -Issl -Ievent -Icpputil -Ievpp -o bin/TcpClientEventLoop_test  evpp/TcpClientEventLoop_test.cpp  -Llib -lhv -pthread
 	$(CXX) -g -Wall -O0 -std=c++11 -I. -Ibase -Issl -Ievent -Icpputil -Ievpp -o bin/UdpServer_test           evpp/UdpServer_test.cpp           -Llib -lhv -pthread
 	$(CXX) -g -Wall -O0 -std=c++11 -I. -Ibase -Issl -Ievent -Icpputil -Ievpp -o bin/UdpClient_test           evpp/UdpClient_test.cpp           -Llib -lhv -pthread
-	$(CXX) -g -Wall -O0 -std=c++11 -I. -Ibase -Issl -Ievent -Icpputil -Ievpp -o bin/UdpMulticast_test        evpp/UdpMulticast_test.cpp        -Llib -lhv -pthread
 
 # UNIX only
 webbench: prepare

--- a/base/hsocket.h
+++ b/base/hsocket.h
@@ -300,8 +300,6 @@ HV_INLINE int udp_multicast_leave(int sockfd, const char* group, const char* loc
     return udp_multicast_leave4(sockfd, group, local_iface);
 }
 
-#endif // HV_HAVE_MULTICAST
-
 // UDP multicast sender options. Each is guarded with #ifdef and returns -1 when
 // the option is unavailable on the platform.
 // _if:   choose the local egress interface. v4 takes the interface IPv4 address
@@ -382,6 +380,8 @@ HV_INLINE int udp_multicast_set_loop(int sockfd, int on DEFAULT(1)) {
     if (ss.ss_family == AF_INET6) return udp_multicast_set_loop6(sockfd, on);
     return udp_multicast_set_loop4(sockfd, on);
 }
+
+#endif // HV_HAVE_MULTICAST
 
 HV_INLINE int ip_v6only(int sockfd, int on DEFAULT(1)) {
 #ifdef IPV6_V6ONLY

--- a/base/hsocket.h
+++ b/base/hsocket.h
@@ -219,36 +219,70 @@ HV_INLINE int udp_broadcast(int sockfd, int on DEFAULT(1)) {
 #define IPV6_DROP_MEMBERSHIP    IPV6_LEAVE_GROUP
 #endif
 
+// Group join/leave use struct ip_mreq / ipv6_mreq. On glibc struct ip_mreq is
+// gated behind __USE_MISC, which strict ISO C (__STRICT_ANSI__, e.g. -std=c99
+// without _GNU_SOURCE) turns off, so the struct is not visible there -- a
+// condition that cannot be expressed with #ifdef. HV_HAVE_MULTICAST captures
+// exactly that case so the group helpers compile out instead of breaking every
+// translation unit that merely includes this header. Everywhere else
+// (macOS/BSD/Windows/Android, musl, any C++ or -std=gnu99 build such as how
+// libhv compiles hsocket.c on Linux) they are available. The scalar sender
+// options further below do not use these structs and are guarded per-function
+// with #ifdef, like ip_v6only().
+#if !(defined(__GLIBC__) && defined(__STRICT_ANSI__) && !defined(__USE_MISC))
+#define HV_HAVE_MULTICAST 1
+#else
+#define HV_HAVE_MULTICAST 0
+#endif
+
+#if HV_HAVE_MULTICAST
+
 // UDP multicast: join/leave a multicast group.
 // v4: local_host is the local interface IPv4 address (NULL/"0.0.0.0" = any).
 // v6: ifindex is the interface index (0 = default), see if_nametoindex().
 HV_INLINE int udp_multicast_join4(int sockfd, const char* group, const char* local_host DEFAULT(NULL)) {
+#ifdef IP_ADD_MEMBERSHIP
     struct ip_mreq mreq;
     memset(&mreq, 0, sizeof(mreq));
     mreq.imr_multiaddr.s_addr = inet_addr(group);
     mreq.imr_interface.s_addr = (local_host && *local_host) ? inet_addr(local_host) : htonl(INADDR_ANY);
     return setsockopt(sockfd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
+#else
+    (void)sockfd; (void)group; (void)local_host; return -1;
+#endif
 }
 HV_INLINE int udp_multicast_leave4(int sockfd, const char* group, const char* local_host DEFAULT(NULL)) {
+#ifdef IP_DROP_MEMBERSHIP
     struct ip_mreq mreq;
     memset(&mreq, 0, sizeof(mreq));
     mreq.imr_multiaddr.s_addr = inet_addr(group);
     mreq.imr_interface.s_addr = (local_host && *local_host) ? inet_addr(local_host) : htonl(INADDR_ANY);
     return setsockopt(sockfd, IPPROTO_IP, IP_DROP_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
+#else
+    (void)sockfd; (void)group; (void)local_host; return -1;
+#endif
 }
 HV_INLINE int udp_multicast_join6(int sockfd, const char* group, unsigned int ifindex DEFAULT(0)) {
+#ifdef IPV6_ADD_MEMBERSHIP
     struct ipv6_mreq mreq;
     memset(&mreq, 0, sizeof(mreq));
     if (inet_pton(AF_INET6, group, &mreq.ipv6mr_multiaddr) != 1) return -1;
     mreq.ipv6mr_interface = ifindex;
     return setsockopt(sockfd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
+#else
+    (void)sockfd; (void)group; (void)ifindex; return -1;
+#endif
 }
 HV_INLINE int udp_multicast_leave6(int sockfd, const char* group, unsigned int ifindex DEFAULT(0)) {
+#ifdef IPV6_DROP_MEMBERSHIP
     struct ipv6_mreq mreq;
     memset(&mreq, 0, sizeof(mreq));
     if (inet_pton(AF_INET6, group, &mreq.ipv6mr_multiaddr) != 1) return -1;
     mreq.ipv6mr_interface = ifindex;
     return setsockopt(sockfd, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
+#else
+    (void)sockfd; (void)group; (void)ifindex; return -1;
+#endif
 }
 
 // Family-agnostic multicast join/leave: dispatches to the v4/v6 variant by
@@ -256,33 +290,97 @@ HV_INLINE int udp_multicast_leave6(int sockfd, const char* group, unsigned int i
 // is the local interface IPv4 address (NULL/"0.0.0.0" = any); it is ignored for
 // IPv6 groups (which use the default interface, ifindex 0).
 HV_INLINE int udp_multicast_join(int sockfd, const char* group, const char* local_iface DEFAULT(NULL)) {
+    if (group == NULL) return -1;
     if (strchr(group, ':')) return udp_multicast_join6(sockfd, group, 0);
     return udp_multicast_join4(sockfd, group, local_iface);
 }
 HV_INLINE int udp_multicast_leave(int sockfd, const char* group, const char* local_iface DEFAULT(NULL)) {
+    if (group == NULL) return -1;
     if (strchr(group, ':')) return udp_multicast_leave6(sockfd, group, 0);
     return udp_multicast_leave4(sockfd, group, local_iface);
 }
 
-// UDP multicast sender options.
-// udp_multicast_set_if4: choose the local interface (by IPv4 address) that
-//   outgoing multicast datagrams egress from.
-// udp_multicast_set_ttl: multicast hop limit (1 = same subnet, default OS is 1).
-// udp_multicast_set_loop: whether the sender also receives its own datagrams
-//   on the same host (on = 1, off = 0).
+#endif // HV_HAVE_MULTICAST
+
+// UDP multicast sender options. Each is guarded with #ifdef and returns -1 when
+// the option is unavailable on the platform.
+// _if:   choose the local egress interface. v4 takes the interface IPv4 address
+//        string; v6 takes the interface index (see if_nametoindex()).
+// _ttl:  multicast hop limit (1 = same subnet, OS default is 1).
+// _loop: whether the sender also receives its own datagrams (on = 1, off = 0).
+// The generic udp_multicast_set_ttl/loop pick v4 or v6 by the socket's family.
 HV_INLINE int udp_multicast_set_if4(int sockfd, const char* local_iface) {
+#ifdef IP_MULTICAST_IF
     struct in_addr addr;
     memset(&addr, 0, sizeof(addr));
     addr.s_addr = (local_iface && *local_iface) ? inet_addr(local_iface) : htonl(INADDR_ANY);
     return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_IF, (const char*)&addr, sizeof(addr));
+#else
+    (void)sockfd; (void)local_iface; return -1;
+#endif
 }
-HV_INLINE int udp_multicast_set_ttl(int sockfd, int ttl) {
+HV_INLINE int udp_multicast_set_ttl4(int sockfd, int ttl) {
+#ifdef IP_MULTICAST_TTL
+#ifdef OS_WIN
+    // Winsock wants a DWORD-sized optval for IP_MULTICAST_TTL.
+    int v = ttl;
+#else
     unsigned char v = (unsigned char)ttl;
+#endif
     return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_TTL, (const char*)&v, sizeof(v));
+#else
+    (void)sockfd; (void)ttl; return -1;
+#endif
+}
+HV_INLINE int udp_multicast_set_loop4(int sockfd, int on DEFAULT(1)) {
+#ifdef IP_MULTICAST_LOOP
+#ifdef OS_WIN
+    int v = on ? 1 : 0;
+#else
+    unsigned char v = on ? 1 : 0;
+#endif
+    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_LOOP, (const char*)&v, sizeof(v));
+#else
+    (void)sockfd; (void)on; return -1;
+#endif
+}
+HV_INLINE int udp_multicast_set_if6(int sockfd, unsigned int ifindex) {
+#ifdef IPV6_MULTICAST_IF
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_MULTICAST_IF, (const char*)&ifindex, sizeof(ifindex));
+#else
+    (void)sockfd; (void)ifindex; return -1;
+#endif
+}
+HV_INLINE int udp_multicast_set_ttl6(int sockfd, int hops) {
+#ifdef IPV6_MULTICAST_HOPS
+    // IPv6 multicast options take an int optval.
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (const char*)&hops, sizeof(hops));
+#else
+    (void)sockfd; (void)hops; return -1;
+#endif
+}
+HV_INLINE int udp_multicast_set_loop6(int sockfd, int on DEFAULT(1)) {
+#ifdef IPV6_MULTICAST_LOOP
+    int v = on ? 1 : 0;
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, (const char*)&v, sizeof(v));
+#else
+    (void)sockfd; (void)on; return -1;
+#endif
+}
+// Generic ttl/loop: pick v4 or v6 by the socket's address family.
+HV_INLINE int udp_multicast_set_ttl(int sockfd, int ttl) {
+    struct sockaddr_storage ss;
+    socklen_t len = sizeof(ss);
+    if (getsockname(sockfd, (struct sockaddr*)&ss, &len) != 0) return -1;
+    if (ss.ss_family == AF_INET6) return udp_multicast_set_ttl6(sockfd, ttl);
+    return udp_multicast_set_ttl4(sockfd, ttl);
 }
 HV_INLINE int udp_multicast_set_loop(int sockfd, int on DEFAULT(1)) {
-    unsigned char v = (unsigned char)on;
-    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_LOOP, (const char*)&v, sizeof(v));
+    struct sockaddr_storage ss;
+    socklen_t len = sizeof(ss);
+    if (getsockname(sockfd, (struct sockaddr*)&ss, &len) != 0) return -1;
+    if (ss.ss_family == AF_INET6) return udp_multicast_set_loop6(sockfd, on);
+    return udp_multicast_set_loop4(sockfd, on);
 }
 
 HV_INLINE int ip_v6only(int sockfd, int on DEFAULT(1)) {

--- a/base/hsocket.h
+++ b/base/hsocket.h
@@ -210,6 +210,81 @@ HV_INLINE int udp_broadcast(int sockfd, int on DEFAULT(1)) {
     return setsockopt(sockfd, SOL_SOCKET, SO_BROADCAST, (const char*)&on, sizeof(int));
 }
 
+// Some platforms spell the IPv6 group options IPV6_JOIN_GROUP/IPV6_LEAVE_GROUP,
+// others IPV6_ADD_MEMBERSHIP/IPV6_DROP_MEMBERSHIP; they are the same option.
+#if !defined(IPV6_ADD_MEMBERSHIP) && defined(IPV6_JOIN_GROUP)
+#define IPV6_ADD_MEMBERSHIP     IPV6_JOIN_GROUP
+#endif
+#if !defined(IPV6_DROP_MEMBERSHIP) && defined(IPV6_LEAVE_GROUP)
+#define IPV6_DROP_MEMBERSHIP    IPV6_LEAVE_GROUP
+#endif
+
+// UDP multicast: join/leave a multicast group.
+// v4: local_host is the local interface IPv4 address (NULL/"0.0.0.0" = any).
+// v6: ifindex is the interface index (0 = default), see if_nametoindex().
+HV_INLINE int udp_multicast_join4(int sockfd, const char* group, const char* local_host DEFAULT(NULL)) {
+    struct ip_mreq mreq;
+    memset(&mreq, 0, sizeof(mreq));
+    mreq.imr_multiaddr.s_addr = inet_addr(group);
+    mreq.imr_interface.s_addr = (local_host && *local_host) ? inet_addr(local_host) : htonl(INADDR_ANY);
+    return setsockopt(sockfd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
+}
+HV_INLINE int udp_multicast_leave4(int sockfd, const char* group, const char* local_host DEFAULT(NULL)) {
+    struct ip_mreq mreq;
+    memset(&mreq, 0, sizeof(mreq));
+    mreq.imr_multiaddr.s_addr = inet_addr(group);
+    mreq.imr_interface.s_addr = (local_host && *local_host) ? inet_addr(local_host) : htonl(INADDR_ANY);
+    return setsockopt(sockfd, IPPROTO_IP, IP_DROP_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
+}
+HV_INLINE int udp_multicast_join6(int sockfd, const char* group, unsigned int ifindex DEFAULT(0)) {
+    struct ipv6_mreq mreq;
+    memset(&mreq, 0, sizeof(mreq));
+    if (inet_pton(AF_INET6, group, &mreq.ipv6mr_multiaddr) != 1) return -1;
+    mreq.ipv6mr_interface = ifindex;
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
+}
+HV_INLINE int udp_multicast_leave6(int sockfd, const char* group, unsigned int ifindex DEFAULT(0)) {
+    struct ipv6_mreq mreq;
+    memset(&mreq, 0, sizeof(mreq));
+    if (inet_pton(AF_INET6, group, &mreq.ipv6mr_multiaddr) != 1) return -1;
+    mreq.ipv6mr_interface = ifindex;
+    return setsockopt(sockfd, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP, (const char*)&mreq, sizeof(mreq));
+}
+
+// Family-agnostic multicast join/leave: dispatches to the v4/v6 variant by
+// detecting an IPv6 group address (contains ':'). For IPv4 groups, local_iface
+// is the local interface IPv4 address (NULL/"0.0.0.0" = any); it is ignored for
+// IPv6 groups (which use the default interface, ifindex 0).
+HV_INLINE int udp_multicast_join(int sockfd, const char* group, const char* local_iface DEFAULT(NULL)) {
+    if (strchr(group, ':')) return udp_multicast_join6(sockfd, group, 0);
+    return udp_multicast_join4(sockfd, group, local_iface);
+}
+HV_INLINE int udp_multicast_leave(int sockfd, const char* group, const char* local_iface DEFAULT(NULL)) {
+    if (strchr(group, ':')) return udp_multicast_leave6(sockfd, group, 0);
+    return udp_multicast_leave4(sockfd, group, local_iface);
+}
+
+// UDP multicast sender options.
+// udp_multicast_set_if4: choose the local interface (by IPv4 address) that
+//   outgoing multicast datagrams egress from.
+// udp_multicast_set_ttl: multicast hop limit (1 = same subnet, default OS is 1).
+// udp_multicast_set_loop: whether the sender also receives its own datagrams
+//   on the same host (on = 1, off = 0).
+HV_INLINE int udp_multicast_set_if4(int sockfd, const char* local_iface) {
+    struct in_addr addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.s_addr = (local_iface && *local_iface) ? inet_addr(local_iface) : htonl(INADDR_ANY);
+    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_IF, (const char*)&addr, sizeof(addr));
+}
+HV_INLINE int udp_multicast_set_ttl(int sockfd, int ttl) {
+    unsigned char v = (unsigned char)ttl;
+    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_TTL, (const char*)&v, sizeof(v));
+}
+HV_INLINE int udp_multicast_set_loop(int sockfd, int on DEFAULT(1)) {
+    unsigned char v = (unsigned char)on;
+    return setsockopt(sockfd, IPPROTO_IP, IP_MULTICAST_LOOP, (const char*)&v, sizeof(v));
+}
+
 HV_INLINE int ip_v6only(int sockfd, int on DEFAULT(1)) {
 #ifdef IPV6_V6ONLY
     return setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&on, sizeof(int));

--- a/evpp/UdpMulticast_test.cpp
+++ b/evpp/UdpMulticast_test.cpp
@@ -57,7 +57,7 @@ static int run_send(const char* group, int port, const char* iface) {
         return -20;
     }
     if (iface) udp_multicast_set_if4(sockfd, iface);
-    udp_multicast_set_loop(sockfd, 1);  // let same-host receivers get our datagrams
+    udp_multicast_set_loop4(sockfd, 1);  // let same-host receivers get our datagrams
     cli->start();
     printf("send: type a line to multicast to %s:%d ('quit' to exit)\n", group, port);
     std::string line;

--- a/evpp/UdpMulticast_test.cpp
+++ b/evpp/UdpMulticast_test.cpp
@@ -1,0 +1,86 @@
+/*
+ * UdpMulticast_test.cpp
+ *
+ * @build   make evpp
+ * @recv    bin/UdpMulticast_test recv 239.255.0.1 4321 [local_iface]
+ * @send    bin/UdpMulticast_test send 239.255.0.1 4321 [local_iface]
+ *
+ * Receiver: UdpServer bound to the group port, joins the multicast group, and
+ *           prints datagrams. local_iface picks the receiving interface.
+ * Sender:   UdpClient targeting the group address; datagrams are delivered to
+ *           every group member. local_iface picks the egress interface and
+ *           enables loopback so same-host receivers also get them.
+ *
+ * Same-host demo over the loopback interface:
+ *   bin/UdpMulticast_test recv 239.1.2.3 4321 127.0.0.1
+ *   bin/UdpMulticast_test send 239.1.2.3 4321 127.0.0.1
+ */
+
+#include <iostream>
+
+#include "UdpServer.h"
+#include "UdpClient.h"
+
+using namespace hv;
+
+static int run_recv(const char* group, int port, const char* iface) {
+    auto srv = std::make_shared<UdpServer>();
+    // bind to the group port on any local address, then join the group
+    int bindfd = srv->createsocket(port, "0.0.0.0");
+    if (bindfd < 0) {
+        printf("createsocket failed: %d\n", bindfd);
+        return -20;
+    }
+    if (udp_multicast_join(bindfd, group, iface) != 0) {
+        printf("udp_multicast_join(%s) failed\n", group);
+        return -21;
+    }
+    printf("recv: joined %s:%d, waiting for datagrams (Ctrl-C to quit)...\n", group, port);
+    srv->onMessage = [](const SocketChannelPtr& channel, Buffer* buf) {
+        printf("< %.*s\n", (int)buf->size(), (char*)buf->data());
+    };
+    srv->start();
+
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        if (line == "quit") break;
+    }
+    udp_multicast_leave(bindfd, group, iface);
+    return 0;
+}
+
+static int run_send(const char* group, int port, const char* iface) {
+    auto cli = std::make_shared<UdpClient>();
+    int sockfd = cli->createsocket(port, group);
+    if (sockfd < 0) {
+        printf("createsocket failed: %d\n", sockfd);
+        return -20;
+    }
+    if (iface) udp_multicast_set_if4(sockfd, iface);
+    udp_multicast_set_loop(sockfd, 1);  // let same-host receivers get our datagrams
+    cli->start();
+    printf("send: type a line to multicast to %s:%d ('quit' to exit)\n", group, port);
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        if (line == "quit") break;
+        cli->sendto(line);
+    }
+    return 0;
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 4) {
+        printf("Usage: %s recv|send group port [local_iface]\n", argv[0]);
+        printf("   eg: %s recv 239.255.0.1 4321\n", argv[0]);
+        printf("       %s send 239.255.0.1 4321\n", argv[0]);
+        return -10;
+    }
+    const char* mode  = argv[1];
+    const char* group = argv[2];
+    int         port  = atoi(argv[3]);
+    const char* iface = argc > 4 ? argv[4] : NULL;
+    if (strcmp(mode, "recv") == 0) return run_recv(group, port, iface);
+    if (strcmp(mode, "send") == 0) return run_send(group, port, iface);
+    printf("unknown mode: %s\n", mode);
+    return -11;
+}


### PR DESCRIPTION
Adds UDP multicast support (requested in #251 and #468).

Kept intentionally minimal: the helpers live only in `base/hsocket.h` as header-only `HV_INLINE` functions (mirroring `udp_broadcast`), so both C and C++ code can call them directly on a socket fd. No new methods were added to `UdpClient`/`UdpServer` — users pass `createsocket()`'s fd (or `channel->fd()`) to the helper.

### C layer (`base/hsocket.h`)
- `udp_multicast_join` / `udp_multicast_leave` — family-agnostic, dispatch to v4/v6 by detecting `:` in the group address
- explicit variants: `udp_multicast_join4` / `leave4` (IPv4, by local interface address) and `join6` / `leave6` (IPv6, by interface index)
- sender options: `udp_multicast_set_if4` (egress interface), `udp_multicast_set_ttl`, `udp_multicast_set_loop`

### Example
`evpp/UdpMulticast_test.cpp` — a group receiver and sender (wired into `make evpp`), calling the helpers on the fd returned by `UdpServer`/`UdpClient::createsocket()`.

### Cross-platform
Uses `unsigned int` interface index for IPv6 (not the Windows-only `ULONG` that broke the earlier PR #480), and aliases `IPV6_ADD/DROP_MEMBERSHIP` <-> `IPV6_JOIN/LEAVE_GROUP` so it builds on Linux/macOS/BSD/Windows. IPv4 and IPv6 helpers both compile in C (c99) and C++ (with default args).

### Verified
Built `libhv` + the example. End-to-end multicast over the loopback interface (the corp LAN filters multicast here, so lo0 was used):
- libhv sender -> libhv receiver: received all datagrams
- libhv sender -> python receiver: received all datagrams
- python sender -> python receiver: baseline OK

So join/leave, egress-interface selection and loopback all work in practice, not just returning 0 from setsockopt.

Closes #251
Closes #468
