### PR TITLE
fix(websocket): OOB read from oversized/wrapped frame length (#852)

### DIFF
--- a/http/WebSocketParser.cpp
+++ b/http/WebSocketParser.cpp
@@ -12,9 +12,10 @@ static int on_frame_header(websocket_parser* parser) {
     if (opcode != WS_OP_CONTINUE) {
         wp->opcode = opcode;
     }
-    int length = parser->length;
-    int reserve_length = MIN(length + 1, MAX_PAYLOAD_LENGTH);
-    if (reserve_length > wp->message.capacity()) {
+    // parser->length is size_t; use it only as a capacity hint, capped.
+    size_t length = parser->length;
+    size_t reserve_length = MIN(length + 1, (size_t)MAX_PAYLOAD_LENGTH);
+    if (reserve_length > (size_t)wp->message.capacity()) {
         wp->message.reserve(reserve_length);
     }
     if (wp->state == WS_FRAME_BEGIN ||

--- a/http/websocket_parser.c
+++ b/http/websocket_parser.c
@@ -142,7 +142,8 @@ size_t websocket_parser_execute(websocket_parser *parser, const websocket_parser
                 break;
             case s_body:
                 if(parser->require) {
-                    if(p + parser->require <= end) {
+                    // size_t-safe check: `p + require` can overflow/wrap for a huge require.
+                    if(parser->require <= (size_t)(end - p)) {
                         EMIT_DATA_CB(frame_body, p, parser->require);
                         p += parser->require;
                         parser->require = 0;


### PR DESCRIPTION
Fixes #852 — OOB read from an oversized / wrapped WebSocket frame length.

### Root cause
`http/websocket_parser.c` (vendored) checked body availability with:
```c
if (p + parser->require <= end)   // s_body
```
For a peer-declared 64-bit payload length (e.g. all `0xFF`, which also has the MSB set that RFC 6455 §5.2 forbids), `parser->require` is ~`SIZE_MAX`, so `p + parser->require` **overflows the pointer** and wraps to a value ≤ `end`. The check passes and `frame_body` is emitted with `length ≈ SIZE_MAX` while only a few bytes are valid. `WebSocketParser.cpp` then trusts it:
```cpp
websocket_parser_decode((char*)at, at, length, ...);  // in-place, huge length
wp->message.append(at, length);                        // OOB read
```
→ out-of-bounds read / crash for any peer that can send WebSocket frames.

### Fix
- **`websocket_parser.c`**: compare against the real remaining bytes, `parser->require <= (size_t)(end - p)`, which cannot overflow.
- **`WebSocketParser.cpp` `on_frame_header`**: stop truncating `parser->length` (`size_t`) to `int`; use it only as a capacity hint capped to `MAX_PAYLOAD_LENGTH` — never trust a peer-declared length for allocation. (Body bytes are still appended incrementally against real buffer data.)

### Verified
- Crafted frame `81 7F FF FF FF FF FF FF FF FF 41` (FIN+TEXT, 64-bit len all `0xFF`, 1 payload byte):
  - before: `on_frame_body length=18446744073709551615`
  - after:  `on_frame_body length=1`
- Normal frames still parse: unmasked "hello", the same frame split across two `execute()` calls, and a 126/16-bit-length 200-byte frame — all OK.
- `make libhv` + ws client/server examples build clean.

Reported by the issue author (with a minimal C-core repro); this patches the vendored parser and the product-specific amplification in the C++ wrapper.
