### PR TITLE
feat(hlog): add %p (pid) / %t (tid) format specifiers (standalone, supersedes #742)

### DIFF
--- a/base/hlog.c
+++ b/base/hlog.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <time.h>
 
 //#include "hmutex.h"
@@ -24,6 +25,30 @@
 #define hmutex_destroy      pthread_mutex_destroy
 #define hmutex_lock         pthread_mutex_lock
 #define hmutex_unlock       pthread_mutex_unlock
+#endif
+
+// Self-contained pid/tid for the %p/%t format specifiers. hlog is meant to be
+// usable standalone (only depending on hexport.h), so we don't pull in
+// hthread.h/hplatform.h here; instead inline the platform primitives, using
+// the headers already included above (windows.h / pthread.h).
+#ifdef _WIN32
+#define hlog_getpid()   (long)GetCurrentProcessId()
+#define hlog_gettid()   (long)GetCurrentThreadId()
+#else
+#include <unistd.h>         // for getpid
+#define hlog_getpid()   (long)getpid()
+#if defined(__linux__)
+#include <sys/syscall.h>    // for SYS_gettid
+static inline long hlog_gettid() { return (long)syscall(SYS_gettid); }
+#elif defined(__APPLE__)
+static inline long hlog_gettid() {
+    uint64_t tid = 0;
+    pthread_threadid_np(NULL, &tid);
+    return (long)tid;
+}
+#else
+#define hlog_gettid()   (long)pthread_self()
+#endif
 #endif
 
 //#include "htime.h"
@@ -477,6 +502,12 @@ int logger_print(logger_t* logger, int level, const char* fmt, ...) {
                     for (int i = 0; i < 5; ++i) {
                         buf[len++] = plevel[i];
                     }
+                    break;
+                case 'p':
+                    len += snprintf(buf + len, bufsize - len, "%ld", hlog_getpid());
+                    break;
+                case 't':
+                    len += snprintf(buf + len, bufsize - len, "%ld", hlog_gettid());
                     break;
                 case 's':
                 {

--- a/base/hlog.h
+++ b/base/hlog.h
@@ -100,6 +100,8 @@ HV_EXPORT void logger_set_level_by_str(logger_t* logger, const char* level);
  * %Z us
  * %l First character of level
  * %L All characters of level
+ * %p pid (process id)
+ * %t tid (thread id)
  * %s message
  * %% %
  */


### PR DESCRIPTION
Adds `%p` (process id) and `%t` (thread id) log format specifiers.

Reworked version of #742 to respect a design constraint: `hlog.h`/`hlog.c` are meant to be usable **standalone** (depending only on `hexport.h`). #742 did `#include <hthread.h>` to get `hv_getpid()`/`hv_gettid()`, which pulls in `hplatform.h` and breaks that independence.

Instead, this inlines the pid/tid platform primitives directly in `hlog.c`, using the headers it already includes (`windows.h` on Windows; `pthread.h` + `sys/syscall.h`/`SYS_gettid` on Linux, `pthread_threadid_np` on macOS, `pthread_self` fallback) — no `hthread.h`/`hplatform.h` dependency.

## Usage
```c
hlog_set_format("%y-%m-%d %H:%M:%S.%z %L [%p:%t] %s");
```

## Verified
- `hlog.c` compiles **standalone** (`cc -I. -Ibase hlog.c` + a tiny main) — no hthread.h/hplatform.h needed.
- `%p` prints the process id, `%t` the thread id.
- Full `make libhv` builds clean; format doc in `hlog.h` updated.

Supersedes #742 (thanks @mtdxc for the original idea).
