### PR TITLE
fix(http): handle oversized response header in FileCache send path (minimal alt to #823)

### DIFF
--- a/http/server/FileCache.h
+++ b/http/server/FileCache.h
@@ -10,7 +10,7 @@
 #include "hstring.h"
 #include "LRUCache.h"
 
-#define HTTP_HEADER_MAX_LENGTH      1024        // 1K
+#define HTTP_HEADER_MAX_LENGTH      4096        // 4K
 #define FILE_CACHE_MAX_NUM          100
 #define FILE_CACHE_MAX_SIZE         (1 << 22)   // 4M
 
@@ -48,11 +48,16 @@ typedef struct file_cache_s {
         filebuf.len = filesize;
     }
 
-    void prepend_header(const char* header, int len) {
-        if (len > HTTP_HEADER_MAX_LENGTH) return;
+    // Prepend the response header into the space reserved before filebuf so the
+    // header + file content can be sent as one buffer (httpbuf). Returns false
+    // if the header does not fit the reserved space; the caller must then send
+    // the header and filebuf separately (filebuf stays intact either way).
+    bool prepend_header(const char* header, int len) {
+        if (len > HTTP_HEADER_MAX_LENGTH) return false;
         httpbuf.base = filebuf.base - len;
         httpbuf.len = len + filebuf.len;
         memcpy(httpbuf.base, header, len);
+        return true;
     }
 } file_cache_t;
 

--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -856,11 +856,18 @@ int HttpHandler::GetSendData(char** data, size_t* len) {
                 // FileCache
                 // NOTE: no copy filebuf, more efficient
                 header = pResp->Dump(true, false);
-                fc->prepend_header(header.c_str(), header.size());
-                *data = fc->httpbuf.base;
-                *len = fc->httpbuf.len;
-                state = SEND_DONE;
-                return *len;
+                if (fc->prepend_header(header.c_str(), header.size())) {
+                    // header fit the reserved space: send header + file content
+                    // as one buffer.
+                    *data = fc->httpbuf.base;
+                    *len = fc->httpbuf.len;
+                    state = SEND_DONE;
+                    return *len;
+                }
+                // header too large for the reserved space: send the header now,
+                // then the file content (pResp->content points at fc->filebuf).
+                state = SEND_BODY;
+                goto return_header;
             }
             // API service
             content_length = pResp->ContentLength();


### PR DESCRIPTION
Minimal fix for the FileCache oversized-header problem that #823 targets, without #823's larger rework (LRU/concurrency/config changes).

## Problem
`FileCache` reserves a fixed block before the file content so header+body can be sent as one buffer. `prepend_header()` returned `void` and **silently did nothing** when the header exceeded the reserve (1K) — the file was then served with a missing/garbage header, and the caller couldn't tell.

## Fix
- Bump the reserve **1K → 4K** so the fast single-buffer path is taken for normal responses (incl. long cookies / CORS / CSP headers).
- `prepend_header()` now returns `bool`. When the header still doesn't fit, `HttpHandler` falls back to sending the **header first, then the file content** (via the existing `SEND_BODY` state; `pResp->content` already points at `fc->filebuf`) — correct instead of silently broken.

## Verified
- normal static file serve: unchanged (fast path)
- response with a **>4K header**: both the full header and the intact file body are delivered (two-part send)
- a 5000-byte file: served intact

## Relation to #823
This is a smaller, targeted alternative. It fixes the actual correctness bug (silent header drop) with ~20 lines and no changes to LRU / cache concurrency / configurability. If instance-level configurable reserve/size is wanted later, that can be a separate, focused change.
