### PR TITLE
fix(http): don't reset shared req/resp while async response is in flight (#424)

### DIFF
--- a/http/server/HttpHandler.cpp
+++ b/http/server/HttpHandler.cpp
@@ -549,7 +549,7 @@ postprocessor:
         }
     }
 
-    if (writer && writer->state != hv::HttpResponseWriter::SEND_BEGIN) {
+    if (writer && !writer->isBegin()) {
         status_code = HTTP_STATUS_NEXT;
     }
     if (status_code == HTTP_STATUS_NEXT) {
@@ -777,6 +777,18 @@ int HttpHandler::FeedRecvData(const char* data, size_t len) {
     case HttpHandler::HTTP_V1:
     case HttpHandler::HTTP_V2:
         if (state != WANT_RECV) {
+            // A new request arrived on this connection before the previous one
+            // finished. Reset() reuses the same req/resp objects, so if an async
+            // handler on another thread is still producing/sending the previous
+            // response (writer not yet End()ed), resetting here races that thread
+            // and can crash. In that case reject the pipelined/early data and let
+            // the caller close the connection. Otherwise (response already sent)
+            // it is safe to reset for the next keep-alive request.
+            if (writer && !writer->isEnd()) {
+                hloge("[%s:%d] new request while previous async response is still in flight", ip, port);
+                error = ERR_REQUEST;
+                return -1;
+            }
             Reset();
         }
         nfeed = parser->FeedRecvData(data, len);

--- a/http/server/HttpResponseWriter.h
+++ b/http/server/HttpResponseWriter.h
@@ -34,6 +34,12 @@ public:
 
     bool isHttp2() const { return (bool)submitHttp2Response; }
 
+    // isBegin(): nothing has been written yet (still at SEND_BEGIN).
+    // isEnd():   the response has been fully handed off, i.e. End() was called
+    //            (End() is the terminal call in every usage sequence below).
+    bool isBegin() const { return state == SEND_BEGIN; }
+    bool isEnd() const { return end == SEND_END; }
+
     // Begin -> End
     // Begin -> WriteResponse -> End
     // Begin -> WriteStatus -> WriteHeader -> WriteBody -> End


### PR DESCRIPTION
Fixes #424 — potential crash when a new request arrives on a keep-alive connection while an **async** handler is still producing/sending the previous response (also reachable via HTTP pipelining or a malicious peer).

## Root cause
`HttpHandler::Reset()` reuses the same `HttpRequest`/`HttpResponse` objects. In `FeedRecvData`, when the handler wasn't back at `WANT_RECV`, it called `Reset()` **unconditionally**. If an async handler on a worker thread still holds `resp`/`writer` and is writing, that reset races the worker → data race / crash.

## Fix
Only `Reset()` when the previous response has actually been handed off. The completion signal is the **writer's** `end == SEND_END`, not `HttpHandler::state`: an async writer (`HttpResponseWriter`, itself a `SocketChannel`) writes straight to the socket and never advances the handler's send-state machine, so `HttpHandler::state` stays `HANDLE_CONTINUE` for the whole async response.

```cpp
if (state != WANT_RECV) {
    if (writer && writer->end != hv::HttpResponseWriter::SEND_END) {
        // async response still in flight -> reject, close connection
        error = ERR_REQUEST;
        return -1;
    }
    Reset();
}
```

## Verified
- **sync** keep-alive reuse: OK (`curl --next`, single connection)
- **async** keep-alive reuse: OK — both requests reuse `Connection #0`, no spurious close (an earlier `state`-based attempt broke this; the writer-`end` signal is the correct one)
- **pipeline-during-async attack** (`/slow` async 500ms + immediately pipelined `/fast`): connection rejected/closed, **server does not crash and keeps serving**
- `make check`: ~658k keep-alive requests, all OK (no throughput/regression)

## Relation to #814
#814 fixes the same crash by allocating fresh `req`/`resp`/`writer` in `Reset()`. This PR is a smaller alternative that keeps the existing object-reuse and just refuses to reset while the async response is in flight (per the "reject a new request before the previous response is sent" approach). Either addresses #424; this one is a more contained change.
