### PR TITLE
ci: update actions/checkout to v7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
     name: build-linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: build
         run: |
@@ -34,7 +34,7 @@ jobs:
     name: build-windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: build
         run: |
           mkdir cmake-build-win64
@@ -56,7 +56,7 @@ jobs:
     name: build-mac
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: build
         run: |
           ./configure
@@ -71,7 +71,7 @@ jobs:
     name: build-android
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: build
         run: |
           mkdir cmake-build-arm64
@@ -83,7 +83,7 @@ jobs:
     name: build-ios
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: build
         run: |
           mkdir cmake-build-ios

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ jobs:
     name: benchmark
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: prepare
         run: |


### PR DESCRIPTION
Updates actions/checkout from v3 to v7 in CI.yml and benchmark.yml.

Changes:
- actions/checkout v3 -> v7

Validation:
- YAML parses for both workflows after the change
- no other action refs in these files

Scope: .github/workflows/ only.