### PR TITLE
fix: include <fcntl.h> for O_RDONLY on Windows/MSVC

### DIFF
--- a/http/server/FileCache.cpp
+++ b/http/server/FileCache.cpp
@@ -1,5 +1,7 @@
 #include "FileCache.h"
 
+#include <fcntl.h>
+
 #include "herr.h"
 #include "hscope.h"
 #include "htime.h"


### PR DESCRIPTION
### Problem

Building libhv with MSVC on Windows fails in `http/server/FileCache.cpp`:

```
error C2065: "O_RDONLY": undeclared identifier
```

`O_RDONLY` is declared in `<fcntl.h>`, which was not included. It compiled on Linux only because another header happened to pull it in transitively.

### Fix

Add `#include <fcntl.h>`.

### Verification

- OS: Windows 11, MSVC (VS 2022), Ninja + CMake
- Full build `cmake --build .` now succeeds (134/134 targets)
- Discovered while building the project for the first time