### PR TITLE
fix(http): prevent unhandled std::length_error abort from int truncation in chunked parsing

### DIFF
--- a/http/Http1Parser.cpp
+++ b/http/Http1Parser.cpp
@@ -142,8 +142,8 @@ int on_message_complete(http_parser* parser) {
 int on_chunk_header(http_parser* parser) {
     printd("on_chunk_header:%llu\n", parser->content_length);
     Http1Parser* hp = (Http1Parser*)parser->data;
-    int chunk_size = parser->content_length;
-    int reserve_size = MIN(chunk_size + 1, MAX_CONTENT_LENGTH);
+    uint64_t chunk_size = parser->content_length;
+    size_t reserve_size = (size_t)MIN(chunk_size + 1, (uint64_t)MAX_CONTENT_LENGTH);
     if (reserve_size > hp->parsed->body.capacity()) {
         hp->parsed->body.reserve(reserve_size);
     }


### PR DESCRIPTION
## Summary
In `Http1Parser.cpp`, `on_chunk_header()` stores the chunk size
(`parser->content_length`, a `uint64_t`) into an `int chunk_size`. For large
chunk-size values (e.g. `>= 0x80000000`), this truncation produces a negative
value, which is then compared against / passed to `size_t`-typed code and
reinterpreted as a huge unsigned value. This causes
`std::string::reserve()` to throw `std::length_error`. There is no exception
handling anywhere in the receive path, so the exception propagates to
`std::terminate()` and the whole process aborts.

An unauthenticated remote attacker can crash the server deterministically
with a single HTTP request (just a chunk-size header line, no chunk data
required). Commit `7a500fe` ("protect reserve") added a
`MIN(x, MAX_CONTENT_LENGTH)` cap, but it doesn't account for the `int`
truncation, so the mitigation is ineffective.

I reproduced this locally against commit `e129e72` and confirmed the server
process aborts (core dump) with `std::length_error: basic_string::_M_create`.

## Root cause
```c
int chunk_size = parser->content_length;                       // uint64_t -> int truncation
int reserve_size = MIN(chunk_size + 1, MAX_CONTENT_LENGTH);
if (reserve_size > hp->parsed->body.capacity())                // int(negative) -> size_t becomes huge
    hp->parsed->body.reserve(reserve_size);                    // throws std::length_error, uncaught
```

## Fix
Keep `chunk_size`/`reserve_size` unsigned (`uint64_t`/`size_t`) end-to-end so
the truncation can no longer occur.

## Testing
- Before patch: sending a crafted chunked request reproducibly aborts the
  server process (core dump)
- After patch: same request no longer crashes the server; `/ping` still
  responds 200 afterward